### PR TITLE
Arch-Support

### DIFF
--- a/README.md
+++ b/README.md
@@ -235,7 +235,7 @@ By default, script build the version as recommended by Revanced team.
     fact to define your normal configurations in `.env` file and sometimes if you want to build something different just
     once. Add it in `GitHub secrets` or you can ignore `.env` file and always use `GitHub secrets` because to modify
     `.env` you need to modify the repo. Edit it and make a commit.
-11. If you want to build youtube with `original icon` and `custom branding icon` both. Add `BUILD_OG_BRANDING_YOUTUBE`
+11. If you want to build YouTube with `original icon` and `custom branding icon` both. Add `BUILD_OG_BRANDING_YOUTUBE`
     in `.env` file or in `ENVS` in `GitHub secrets` (Recommended) in the format
     ```dotenv
      BUILD_OG_BRANDING_YOUTUBE=True
@@ -246,11 +246,12 @@ By default, script build the version as recommended by Revanced team.
     ```dotenv
      BRANDING_PATCH=custom-branding-icon-blue
     ```
-12. You can build only for `arm64-v8a` devices in order to get smaller apk files.This can be done with by adding
-    `BUILD_ARM64_V8A_ONLY` in `ENVS` in `GitHub secrets` (Recommended) in the format.
+12. You can build only for a particular arch in order to get smaller apk files.This can be done with by adding comma
+    separated `ARCHS_TO_BUILD` in `ENVS` in `GitHub secrets` (Recommended) in the format.
     ```dotenv
-     BUILD_ARM64_V8A_ONLY=True
+     ARCHS_TO_BUILD=arm64-v8a,armeabi-v7a
     ```
+    Possible values for `ARCHS_TO_BUILD` are: `armeabi-v7a`,`x86`,`x86_64`,`arm64-v8a`
     Make sure you are using `revanced-extended` as `revanced` doesn't support this.
 13. Sample Envs ![envs]
 

--- a/src/config.py
+++ b/src/config.py
@@ -61,4 +61,4 @@ class RevancedConfig:
             "BRANDING_PATCH",
             "custom-branding-icon-blue" if self.build_extended else "custom-branding",
         )
-        self.build_arm64_v8a_only = env.bool("BUILD_ARM64_V8A_ONLY", False)
+        self.archs_to_build = env.list("ARCHS_TO_BUILD", [])

--- a/src/parser.py
+++ b/src/parser.py
@@ -8,6 +8,7 @@ from loguru import logger
 
 from src.config import RevancedConfig
 from src.patches import Patches
+from src.utils import possible_archs
 
 
 class Parser(object):
@@ -103,13 +104,11 @@ class Parser(object):
 
         if self._PATCHES:
             args.extend(self._PATCHES)
-        if self.config.build_extended and self.config.build_arm64_v8a_only:
-            args.append("--rip-lib")
-            args.append("armeabi-v7a")
-            args.append("--rip-lib")
-            args.append("x86")
-            args.append("--rip-lib")
-            args.append("x86_64")
+        if self.config.build_extended and len(self.config.archs_to_build) > 0:
+            excluded = set(possible_archs) - set(self.config.archs_to_build)
+            for arch in excluded:
+                args.append("--rip-lib")
+                args.append(arch)
 
         start = perf_counter()
         process = Popen(["java", *args], stdout=PIPE)

--- a/src/utils.py
+++ b/src/utils.py
@@ -8,3 +8,4 @@ supported_apps = [
     "warnwetter",
     "spotify",
 ]
+possible_archs = ["armeabi-v7a", "x86", "x86_64", "arm64-v8a"]


### PR DESCRIPTION
Now you can build apk with only custom archs this helps in reducing apk size. 
You can use `ARCHS_TO_BUILD` env varible.