### PR TITLE
Add MicroG and reddit extended support

### DIFF
--- a/src/config.py
+++ b/src/config.py
@@ -35,7 +35,7 @@ class RevancedConfig(object):
         self.keystore_name = env.str("KEYSTORE_FILE_NAME", "revanced.keystore")
         self.ci_test = env.bool("CI_TEST", False)
         self.apps = env.list("PATCH_APPS", default_build)
-        self.extended_apps: List[str] = ["youtube", "youtube_music", "MicroG"]
+        self.extended_apps: List[str] = ["youtube", "youtube_music", "MicroG", "reddit"]
         self.rip_libs_apps: List[str] = ["youtube"]
         self.normal_cli_jar = "revanced-cli.jar"
         self.normal_patches_jar = "revanced-patches.jar"

--- a/src/config.py
+++ b/src/config.py
@@ -35,7 +35,7 @@ class RevancedConfig(object):
         self.keystore_name = env.str("KEYSTORE_FILE_NAME", "revanced.keystore")
         self.ci_test = env.bool("CI_TEST", False)
         self.apps = env.list("PATCH_APPS", default_build)
-        self.extended_apps: List[str] = ["youtube", "youtube_music"]
+        self.extended_apps: List[str] = ["youtube", "youtube_music", "MicroG"]
         self.rip_libs_apps: List[str] = ["youtube"]
         self.normal_cli_jar = "revanced-cli.jar"
         self.normal_patches_jar = "revanced-patches.jar"

--- a/src/downloader/utils.py
+++ b/src/downloader/utils.py
@@ -29,10 +29,15 @@ def download_revanced(config: RevancedConfig, patcher: Patches) -> None:
             ["inotia00", "revanced-integrations", config.integrations_apk],
             ["inotia00", "revanced-patches", config.patches_jar],
         ]
-    if "youtube" in config.apps or "youtube_music" in config.apps:
-        assets += [
-            ["inotia00", "mMicroG", "mMicroG-output.apk"],
-        ]
+    if "youtube" in config.apps or "youtube_music" in config.apps or "MicroG" in config.apps:
+        if config.build_extended and "MicroG" in config.apps:
+            assets += [
+                ["inotia00", "mMicroG", "MicroG.apk"],
+            ]
+        else:
+            assets += [
+                ["inotia00", "mMicroG", "mMicroG-output.apk"],
+            ]
     downloader = DownloaderFactory.create_downloader(
         app="patches", patcher=patcher, config=config
     )

--- a/src/downloader/utils.py
+++ b/src/downloader/utils.py
@@ -29,7 +29,11 @@ def download_revanced(config: RevancedConfig, patcher: Patches) -> None:
             ["inotia00", "revanced-integrations", config.integrations_apk],
             ["inotia00", "revanced-patches", config.patches_jar],
         ]
-    if "youtube" in config.apps or "youtube_music" in config.apps or "MicroG" in config.apps:
+    if (
+        "youtube" in config.apps
+        or "youtube_music" in config.apps
+        or "MicroG" in config.apps
+    ):
         if config.build_extended and "MicroG" in config.apps:
             assets += [
                 ["inotia00", "mMicroG", "MicroG.apk"],

--- a/src/patches.py
+++ b/src/patches.py
@@ -57,7 +57,8 @@ class Patches(object):
     _revanced_extended_app_ids = {
         "com.google.android.youtube": "youtube",
         "com.google.android.apps.youtube.music": "youtube_music",
-        "com.mgoogle.android.gms": "MicroG"
+        "com.mgoogle.android.gms": "MicroG",
+        "com.reddit.frontpage": "reddit",
     }
     revanced_extended_app_ids = {
         key: (value, "_" + value) for key, value in _revanced_extended_app_ids.items()

--- a/src/patches.py
+++ b/src/patches.py
@@ -57,6 +57,7 @@ class Patches(object):
     _revanced_extended_app_ids = {
         "com.google.android.youtube": "youtube",
         "com.google.android.apps.youtube.music": "youtube_music",
+        "com.mgoogle.android.gms": "MicroG"
     }
     revanced_extended_app_ids = {
         key: (value, "_" + value) for key, value in _revanced_extended_app_ids.items()


### PR DESCRIPTION
This is proposed in response to add extended patch support for microg (any flavor: `TeamVanced/VancedMicroG`, `inotia00/VancedMicroG`, `inotia00/mMicroG`; only patched by extended) and reddit.

Kindly have a look at it. 