### PR TITLE
Change Google Recorder source to Uptodown

### DIFF
--- a/README.md
+++ b/README.md
@@ -185,7 +185,7 @@ You can use any of the following methods to build.
     23. [instagram](https://www.apkmirror.com/apk/instagram/instagram-instagram/)
     24. [inshorts](https://www.apkmirror.com/apk/inshorts-formerly-news-in-shorts/)
     25. [facebook](https://www.apkmirror.com/apk/facebook-2/facebook/)
-    26. [grecorder](https://www.apkmirror.com/apk/google-inc/google-recorder/)
+    26. [opnemer](https://opnemer.en.uptodown.com/android)
     27. [trakt](https://www.apkmirror.com/apk/trakt/trakt/)
     28. [candyvpn](https://www.apkmirror.com/apk/liondev-io/candylink-vpn/)
     29. [sonyheadphone](https://www.apkmirror.com/apk/sony-corporation/sony-headphones-connect/)

--- a/README.md
+++ b/README.md
@@ -185,7 +185,7 @@ You can use any of the following methods to build.
     23. [instagram](https://www.apkmirror.com/apk/instagram/instagram-instagram/)
     24. [inshorts](https://www.apkmirror.com/apk/inshorts-formerly-news-in-shorts/)
     25. [messenger](https://www.apkmirror.com/apk/facebook-2/messenger/)
-    26. [opnemer](https://opnemer.en.uptodown.com/android)
+    26. [grecorder](https://opnemer.en.uptodown.com/android)
     27. [trakt](https://www.apkmirror.com/apk/trakt/trakt/)
     28. [candyvpn](https://www.apkmirror.com/apk/liondev-io/candylink-vpn/)
     29. [sonyheadphone](https://www.apkmirror.com/apk/sony-corporation/sony-headphones-connect/)

--- a/src/config.py
+++ b/src/config.py
@@ -33,7 +33,7 @@ class RevancedConfig(object):
             "irplus",
             "meme-generator-free",
             "yuka",
-            "opnemer",
+            "grecorder",
         ]
         self.apk_pure = ["hex-editor", "androidtwelvewidgets"]
         self.apk_sos = ["expensemanager", "candyvpn"]

--- a/src/config.py
+++ b/src/config.py
@@ -24,17 +24,17 @@ class RevancedConfig(object):
         self.session = Session()
         self.session.headers["User-Agent"] = "anything"
         self.apk_mirror = "https://www.apkmirror.com"
-        self.upto_down = [
-            "spotify",
-            "nyx-music-player",
-            "my-expenses",
-            "backdrops",
-            "twitch",
-            "irplus",
-            "meme-generator-free",
-            "yuka",
-            "grecorder",
-        ]
+        self.upto_down_aliases = {
+            "spotify": "spotify",
+            "nyx-music-player": "nyx-music-player",
+            "my-expenses": "my-expenses",
+            "backdrops": "backdrops",
+            "twitch": "twitch",
+            "irplus": "irplus",
+            "meme-generator-free": "meme-generator-free",
+            "yuka": "yuka",
+            "grecorder": "opnemer",
+        }
         self.apk_pure = ["hex-editor", "androidtwelvewidgets"]
         self.apk_sos = ["expensemanager", "candyvpn"]
         self.ci_test = env.bool("CI_TEST", False)

--- a/src/config.py
+++ b/src/config.py
@@ -33,6 +33,7 @@ class RevancedConfig(object):
             "irplus",
             "meme-generator-free",
             "yuka",
+            "opnemer"
         ]
         self.apk_pure = ["hex-editor", "androidtwelvewidgets"]
         self.apk_sos = ["expensemanager", "candyvpn"]
@@ -57,7 +58,6 @@ class RevancedConfig(object):
             "instagram": f"{self.apk_mirror}/apk/instagram/instagram-instagram/",
             "inshorts": f"{self.apk_mirror}/apk/inshorts-formerly-news-in-shorts/",
             "messenger": f"{self.apk_mirror}/apk/facebook-2/messenger/",
-            "grecorder": f"{self.apk_mirror}/apk/google-inc/google-recorder/",
             "trakt": f"{self.apk_mirror}/apk/trakt/trakt/",
             "candyvpn": f"{self.apk_mirror}/apk/liondev-io/candylink-vpn/",
             "sonyheadphone": f"{self.apk_mirror}/apk/sony-corporation/sony-headphones-connect/",

--- a/src/config.py
+++ b/src/config.py
@@ -33,7 +33,7 @@ class RevancedConfig(object):
             "irplus",
             "meme-generator-free",
             "yuka",
-            "opnemer"
+            "opnemer",
         ]
         self.apk_pure = ["hex-editor", "androidtwelvewidgets"]
         self.apk_sos = ["expensemanager", "candyvpn"]

--- a/src/config.py
+++ b/src/config.py
@@ -24,7 +24,7 @@ class RevancedConfig(object):
         self.session = Session()
         self.session.headers["User-Agent"] = "anything"
         self.apk_mirror = "https://www.apkmirror.com"
-        self.upto_down_aliases = {
+        self.upto_down = {
             "spotify": "spotify",
             "nyx-music-player": "nyx-music-player",
             "my-expenses": "my-expenses",

--- a/src/downloader/uptodown.py
+++ b/src/downloader/uptodown.py
@@ -27,7 +27,7 @@ class UptoDown(Downloader):
         :return: Version of downloaded apk
         """
         logger.debug("downloading specified version of app from uptodown.")
-        url = f"https://{self.upto_down_aliases.get(app)}.en.uptodown.com/android/versions"
+        url = f"https://{self.upto_down.get(app)}.en.uptodown.com/android/versions"
         html = self.config.session.get(url).text
         soup = BeautifulSoup(html, "html.parser")
         versions_list = soup.find("section", {"id": "versions"})

--- a/src/downloader/uptodown.py
+++ b/src/downloader/uptodown.py
@@ -27,7 +27,7 @@ class UptoDown(Downloader):
         :return: Version of downloaded apk
         """
         logger.debug("downloading specified version of app from uptodown.")
-        url = f"https://{self.upto_down.get(app)}.en.uptodown.com/android/versions"
+        url = f"https://{self.config.upto_down.get(app)}.en.uptodown.com/android/versions"
         html = self.config.session.get(url).text
         soup = BeautifulSoup(html, "html.parser")
         versions_list = soup.find("section", {"id": "versions"})

--- a/src/downloader/uptodown.py
+++ b/src/downloader/uptodown.py
@@ -27,7 +27,9 @@ class UptoDown(Downloader):
         :return: Version of downloaded apk
         """
         logger.debug("downloading specified version of app from uptodown.")
-        url = f"https://{self.config.upto_down.get(app)}.en.uptodown.com/android/versions"
+        url = (
+            f"https://{self.config.upto_down.get(app)}.en.uptodown.com/android/versions"
+        )
         html = self.config.session.get(url).text
         soup = BeautifulSoup(html, "html.parser")
         versions_list = soup.find("section", {"id": "versions"})
@@ -43,5 +45,7 @@ class UptoDown(Downloader):
         logger.debug(f"Downloaded {app} apk from upto_down_downloader in rt")
 
     def latest_version(self, app: str, **kwargs: Any) -> None:
-        page = f"https://{self.config.upto_down.get(app)}.en.uptodown.com/android/download"
+        page = (
+            f"https://{self.config.upto_down.get(app)}.en.uptodown.com/android/download"
+        )
         self.extract_download_link(page, app)

--- a/src/downloader/uptodown.py
+++ b/src/downloader/uptodown.py
@@ -27,9 +27,7 @@ class UptoDown(Downloader):
         :return: Version of downloaded apk
         """
         logger.debug("downloading specified version of app from uptodown.")
-        url = (
-            f"https://{self.config.upto_down.get(app)}.en.uptodown.com/android/versions"
-        )
+        url = f"https://{self.config.upto_down.get(app)}.en.uptodown.com/android/versions"
         html = self.config.session.get(url).text
         soup = BeautifulSoup(html, "html.parser")
         versions_list = soup.find("section", {"id": "versions"})
@@ -45,5 +43,5 @@ class UptoDown(Downloader):
         logger.debug(f"Downloaded {app} apk from upto_down_downloader in rt")
 
     def latest_version(self, app: str, **kwargs: Any) -> None:
-        page = f"https://{app}.en.uptodown.com/android/download"
+        page = f"https://{self.config.upto_down.get(app)}.en.uptodown.com/android/download"
         self.extract_download_link(page, app)

--- a/src/downloader/uptodown.py
+++ b/src/downloader/uptodown.py
@@ -27,7 +27,7 @@ class UptoDown(Downloader):
         :return: Version of downloaded apk
         """
         logger.debug("downloading specified version of app from uptodown.")
-        url = f"https://{app}.en.uptodown.com/android/versions"
+        url = f"https://{self.upto_down_aliases.get(app)}.en.uptodown.com/android/versions"
         html = self.config.session.get(url).text
         soup = BeautifulSoup(html, "html.parser")
         versions_list = soup.find("section", {"id": "versions"})

--- a/src/downloader/uptodown.py
+++ b/src/downloader/uptodown.py
@@ -27,7 +27,9 @@ class UptoDown(Downloader):
         :return: Version of downloaded apk
         """
         logger.debug("downloading specified version of app from uptodown.")
-        url = f"https://{self.config.upto_down.get(app)}.en.uptodown.com/android/versions"
+        url = (
+            f"https://{self.config.upto_down.get(app)}.en.uptodown.com/android/versions"
+        )
         html = self.config.session.get(url).text
         soup = BeautifulSoup(html, "html.parser")
         versions_list = soup.find("section", {"id": "versions"})

--- a/src/patches.py
+++ b/src/patches.py
@@ -36,7 +36,7 @@ class Patches(object):
         "com.instagram.android": "instagram",
         "com.nis.app": "inshorts",
         "com.facebook.orca": "messenger",
-        "com.google.android.apps.recorder": "grecorder",
+        "com.google.android.apps.recorder": "opnemer",
         "tv.trakt.trakt": "trakt",
         "com.candylink.openvpn": "candyvpn",
         "com.sony.songpal.mdr": "sonyheadphone",

--- a/src/patches.py
+++ b/src/patches.py
@@ -36,7 +36,7 @@ class Patches(object):
         "com.instagram.android": "instagram",
         "com.nis.app": "inshorts",
         "com.facebook.orca": "messenger",
-        "com.google.android.apps.recorder": "opnemer",
+        "com.google.android.apps.recorder": "grecorder",
         "tv.trakt.trakt": "trakt",
         "com.candylink.openvpn": "candyvpn",
         "com.sony.songpal.mdr": "sonyheadphone",


### PR DESCRIPTION
As there are mostly bundles on APKMirror for Google Recorder now, it won't be able to download the latest version when we don't specify one.