### PR TITLE
🐛 Fix Uptodown downloader

### DIFF
--- a/src/downloader/uptodown.py
+++ b/src/downloader/uptodown.py
@@ -31,7 +31,7 @@ class UptoDown(Downloader):
         download_url = f"https://dw.uptodown.com/dwn/{data_url}"
         file_name = f"{app}.apk"
         self._download(download_url, file_name)
-        
+
         return file_name, download_url
 
     def specific_version(self: Self, app: APP, version: str) -> tuple[str, str]:

--- a/src/downloader/uptodown.py
+++ b/src/downloader/uptodown.py
@@ -8,7 +8,7 @@ from loguru import logger
 from src.app import APP
 from src.downloader.download import Downloader
 from src.exceptions import UptoDownAPKDownloadError
-from src.utils import bs4_parser, handle_request_response, request_header, request_timeout, session
+from src.utils import bs4_parser, handle_request_response, request_header, request_timeout
 
 
 class UptoDown(Downloader):
@@ -38,7 +38,7 @@ class UptoDown(Downloader):
         download_url = f"https://dw.uptodown.com/dwn/{data_url}"
         file_name = f"{app_name}.apk"
         self._download(download_url, file_name)
-        
+
         return file_name, download_url
 
     def specific_version(self: Self, app: APP, version: str) -> tuple[str, str]:

--- a/src/downloader/uptodown.py
+++ b/src/downloader/uptodown.py
@@ -54,8 +54,9 @@ class UptoDown(Downloader):
         app_code = detail_app_name.get("code")
         version_page = 1
         download_url = None
+        version_found = False
 
-        while True:
+        while not version_found:
             version_url = f"{app.download_source}/apps/{app_code}/versions/{version_page}"
             r = requests.get(version_url, timeout=request_timeout)
             handle_request_response(r, version_url)
@@ -67,6 +68,7 @@ class UptoDown(Downloader):
             for item in json["data"]:
                 if item["version"] == version:
                     download_url = item["versionURL"]
+                    version_found = True
                     break
 
             version_page += 1

--- a/src/downloader/uptodown.py
+++ b/src/downloader/uptodown.py
@@ -2,7 +2,7 @@
 from typing import Any, Self
 
 import requests
-from bs4 import BeautifulSoup
+from bs4 import BeautifulSoup, Tag
 from loguru import logger
 
 from src.app import APP
@@ -23,7 +23,7 @@ class UptoDown(Downloader):
         soup = BeautifulSoup(download_page_html, bs4_parser)
         post_download = soup.find("div", class_="post-download")
 
-        if not post_download:
+        if not isinstance(post_download, Tag):
             msg = f"Unable to download {app} from uptodown."
             raise UptoDownAPKDownloadError(msg, url=page)
 
@@ -47,7 +47,7 @@ class UptoDown(Downloader):
         soup = BeautifulSoup(html, bs4_parser)
         detail_app_name = soup.find("h1", id="detail-app-name")
 
-        if not detail_app_name:
+        if not isinstance(detail_app_name, Tag):
             msg = f"Unable to download {app} from uptodown."
             raise UptoDownAPKDownloadError(msg, url=url)
 
@@ -81,4 +81,4 @@ class UptoDown(Downloader):
         """Function to download the latest version of app from uptodown."""
         logger.debug("downloading latest version of app from uptodown.")
         page = f"{app.download_source}/download"
-        return self.extract_download_link(page, app)
+        return self.extract_download_link(page, app.app_name)


### PR DESCRIPTION
The uptodown downloader is currently broken for both latest version and specific version downloads due to site structure changes. This PR fixes it by:
- Using direct download link, just like how they are doing
- Finding the specific version with their API