### PR TITLE
Add request headers for uptodown specific version downloader

### DIFF
--- a/src/downloader/uptodown.py
+++ b/src/downloader/uptodown.py
@@ -58,7 +58,7 @@ class UptoDown(Downloader):
 
         while not version_found:
             version_url = f"{app.download_source}/apps/{app_code}/versions/{version_page}"
-            r = requests.get(version_url, timeout=request_timeout)
+            r = requests.get(version_url, headers=request_header, timeout=request_timeout)
             handle_request_response(r, version_url)
             json = r.json()
 


### PR DESCRIPTION
Lacking of headers seemed to make uptodown detect the downloader as a bad bot and responded with a 429 error.