### PR TITLE
Fix download page Uptodown

### DIFF
--- a/src/downloader/uptodown.py
+++ b/src/downloader/uptodown.py
@@ -66,7 +66,7 @@ class UptoDown(Downloader):
 
             for item in json["data"]:
                 if item["version"] == version:
-                    download_url = item["versionURL"]
+                    download_url = f"{item["versionURL"]}-x"
                     version_found = True
                     break
 


### PR DESCRIPTION
### **User description**
This will fix some Uptodown download pages showing Uptodown Store
![Screenshot_2024-11-20-09-29-13-865_com microsoft emmx](https://github.com/user-attachments/assets/cc89f4ff-e9bd-4bb6-886c-9c89f98e46fc)
![Screenshot_2024-11-20-09-29-23-748_com microsoft emmx](https://github.com/user-attachments/assets/9d7a2149-06a8-4880-a16e-16a0925f7e6b)
![Screenshot_2024-11-20-09-29-33-828_com microsoft emmx](https://github.com/user-attachments/assets/6abd5858-2295-45c3-b2b3-8bf628771be6)


___

### **PR Type**
bug_fix


___

### **Description**
- Fixed the issue with Uptodown download pages by appending '-x' to the `download_url` for specific version downloads.
- Ensures that the correct download URL is generated for the specified app version.



___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>uptodown.py</strong><dd><code>Fix URL format for Uptodown specific version downloads</code>&nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/downloader/uptodown.py

<li>Modified the <code>download_url</code> assignment to append '-x' to the URL.<br> <li> Ensures correct URL format for specific version downloads.<br>


</details>


  </td>
  <td><a href="https://github.com/nikhilbadyal/docker-py-revanced/pull/583/files#diff-5fc51b26ebd6bfba6973761541fe04a8ccae4f8c625b63c72e918c861d308a77">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**: Comment `/help "your question"` on any pull request to receive relevant information