### PR TITLE
🐛 Fix Uptodown download page

### DIFF
--- a/src/downloader/uptodown.py
+++ b/src/downloader/uptodown.py
@@ -27,7 +27,9 @@ class UptoDown(Downloader):
             raise UptoDownAPKDownloadError(msg, url=page)
 
         if "download-link-deeplink" in detail_download_button.get("onclick", ""):
-            logger.debug("Detected Uptodown Store data-url link. Adding '-x' to the URL to redirect to the expanded download page.")
+            logger.debug(
+                "Detected Uptodown Store data-url link. Adding '-x' to the URL to redirect to the expanded download page."
+            )
             page += "-x"
             r = requests.get(page, headers=request_header, allow_redirects=True, timeout=request_timeout)
             handle_request_response(r, page)


### PR DESCRIPTION
### **User description**
This change helps to use the correct link when encountering the Uptodown Store download button( add '+x' to end of versionURL), and when encountering the asset download button, the old link (versionURL) will be used.


___

### **PR Type**
Bug fix


___

### **Description**
- Fixed the handling of Uptodown Store download links by appending '-x' to the URL when necessary.
- Improved error handling by raising exceptions if download URLs are not retrieved.
- Corrected logging messages for consistency in capitalization.
- Removed the unnecessary addition of '-x' to version URLs in specific version downloads.



___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>uptodown.py</strong><dd><code>Fix Uptodown download link handling and improve error checks</code></dd></summary>
<hr>

src/downloader/uptodown.py

<li>Added logic to handle Uptodown Store download links by appending '-x' <br>to the URL.<br> <li> Improved error handling for missing download URLs.<br> <li> Corrected logging messages for consistency.<br> <li> Removed unnecessary URL modification for specific version downloads.<br>


</details>


  </td>
  <td><a href="https://github.com/nikhilbadyal/docker-py-revanced/pull/584/files#diff-5fc51b26ebd6bfba6973761541fe04a8ccae4f8c625b63c72e918c861d308a77">+19/-3</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**: Comment `/help "your question"` on any pull request to receive relevant information