### PR TITLE
🐛 Fix Uptodown download page

### DIFF
--- a/src/downloader/uptodown.py
+++ b/src/downloader/uptodown.py
@@ -28,7 +28,7 @@ class UptoDown(Downloader):
 
         if "download-link-deeplink" in detail_download_button.get("onclick", ""):
             logger.debug(
-                "Detected Uptodown Store data-url link. Adding '-x' to the URL to redirect to the expanded download page."
+                "Detected Uptodown Store data-url link. Adding '-x' to the URL to redirect to the expanded download page.",
             )
             page += "-x"
             r = requests.get(page, headers=request_header, allow_redirects=True, timeout=request_timeout)

--- a/src/downloader/uptodown.py
+++ b/src/downloader/uptodown.py
@@ -26,7 +26,25 @@ class UptoDown(Downloader):
             msg = f"Unable to download {app} from uptodown."
             raise UptoDownAPKDownloadError(msg, url=page)
 
+        if "download-link-deeplink" in detail_download_button.get("onclick", ""):
+            logger.debug(
+                "Detected Uptodown Store data-url link. Adding '-x' to the URL to redirect to the expanded download page."
+            )
+            page += "-x"
+            r = requests.get(page, headers=request_header, allow_redirects=True, timeout=request_timeout)
+            handle_request_response(r, page)
+            soup = BeautifulSoup(r.text, bs4_parser)
+            detail_download_button = soup.find("button", id="detail-download-button")
+
+            if not isinstance(detail_download_button, Tag):
+                msg = f"Unable to download {app} from uptodown after updating URL."
+                raise UptoDownAPKDownloadError(msg, url=page)
+
         data_url = detail_download_button.get("data-url")
+        if not data_url:
+            msg = f"Failed to retrieve download URL for {app}."
+            raise UptoDownAPKDownloadError(msg, url=page)
+
         download_url = f"https://dw.uptodown.com/dwn/{data_url}"
         file_name = f"{app}.apk"
         self._download(download_url, file_name)
@@ -40,7 +58,7 @@ class UptoDown(Downloader):
         :param version: Version of the application to download
         :return: Version of downloaded apk
         """
-        logger.debug("downloading specified version of app from uptodown.")
+        logger.debug("Downloading specified version of app from uptodown.")
         url = f"{app.download_source}/versions"
         html = requests.get(url, headers=request_header, timeout=request_timeout).text
         soup = BeautifulSoup(html, bs4_parser)
@@ -66,7 +84,7 @@ class UptoDown(Downloader):
 
             for item in json["data"]:
                 if item["version"] == version:
-                    download_url = f"{item["versionURL"]}-x"
+                    download_url = item["versionURL"]
                     version_found = True
                     break
 
@@ -80,6 +98,6 @@ class UptoDown(Downloader):
 
     def latest_version(self: Self, app: APP, **kwargs: Any) -> tuple[str, str]:
         """Function to download the latest version of app from uptodown."""
-        logger.debug("downloading latest version of app from uptodown.")
+        logger.debug("Downloading latest version of app from uptodown.")
         page = f"{app.download_source}/download"
         return self.extract_download_link(page, app.app_name)


### PR DESCRIPTION
### **User description**
Add '-x' to the versionURL only when the download page requires the Uptodown App Store.


___

### **PR Type**
Bug fix


___

### **Description**
- Fixed the issue with extracting download links by appending '-x' to the URL when the "download-link-deeplink" is detected.
- Enhanced error handling by checking for missing `data-url` attributes and raising appropriate exceptions.
- Corrected logging messages to maintain consistency in capitalization.
- Removed the unnecessary '-x' suffix from version URLs in the `specific_version` method.



___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>uptodown.py</strong><dd><code>Fix download link extraction and improve error handling</code>&nbsp; &nbsp; </dd></summary>
<hr>

src/downloader/uptodown.py

<li>Added logic to append '-x' to the URL when a specific condition is <br>met.<br> <li> Improved error handling for missing download URLs.<br> <li> Corrected logging messages for consistency.<br> <li> Removed unnecessary '-x' suffix for version URLs.<br>


</details>


  </td>
  <td><a href="https://github.com/nikhilbadyal/docker-py-revanced/pull/586/files#diff-5fc51b26ebd6bfba6973761541fe04a8ccae4f8c625b63c72e918c861d308a77">+21/-3</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**: Comment `/help "your question"` on any pull request to receive relevant information