### PR TITLE
🐛 Fix Uptodown download page

### DIFF
--- a/src/downloader/uptodown.py
+++ b/src/downloader/uptodown.py
@@ -21,7 +21,7 @@ class UptoDown(Downloader):
         handle_request_response(r, page)
         soup = BeautifulSoup(r.text, bs4_parser)
         detail_download_button = soup.find("button", id="detail-download-button")
-        if "download-link-deeplink" in detail_download_button['onclick']:
+        if "download-link-deeplink" in detail_download_button["onclick"]:
             handle_request_response(r, f"{page} +x")
             soup = BeautifulSoup(r.text, bs4_parser)
             detail_download_button = soup.find("button", id="detail-download-button")

--- a/src/downloader/uptodown.py
+++ b/src/downloader/uptodown.py
@@ -21,6 +21,10 @@ class UptoDown(Downloader):
         handle_request_response(r, page)
         soup = BeautifulSoup(r.text, bs4_parser)
         detail_download_button = soup.find("button", id="detail-download-button")
+        if "download-link-deeplink" in detail_download_button['onclick']:
+            handle_request_response(r, f"{page} +x")
+            soup = BeautifulSoup(r.text, bs4_parser)
+            detail_download_button = soup.find("button", id="detail-download-button")
 
         if not isinstance(detail_download_button, Tag):
             msg = f"Unable to download {app} from uptodown."
@@ -66,7 +70,7 @@ class UptoDown(Downloader):
 
             for item in json["data"]:
                 if item["version"] == version:
-                    download_url = f"{item["versionURL"]}-x"
+                    download_url = item["versionURL"]
                     version_found = True
                     break
 


### PR DESCRIPTION
### **User description**
Only expand page when download page shows Uptodown App Store


___

### **PR Type**
Bug fix


___

### **Description**
- Fixed an issue where the download page was incorrectly expanded by checking for "download-link-deeplink" in the button's `onclick` attribute.
- Removed unnecessary string concatenation in the download URL to ensure the correct URL is used.
- Improved the logic for extracting the download link from the Uptodown page.



___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>uptodown.py</strong><dd><code>Fix and improve Uptodown download link extraction logic</code>&nbsp; &nbsp; </dd></summary>
<hr>

src/downloader/uptodown.py

<li>Added a check for "download-link-deeplink" in the button's <code>onclick</code> <br>attribute.<br> <li> Removed unnecessary string concatenation in the download URL.<br> <li> Improved logic to handle download link extraction.<br>


</details>


  </td>
  <td><a href="https://github.com/nikhilbadyal/docker-py-revanced/pull/589/files#diff-5fc51b26ebd6bfba6973761541fe04a8ccae4f8c625b63c72e918c861d308a77">+5/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**: Comment `/help "your question"` on any pull request to receive relevant information