### PR TITLE
🐛 Fix Uptodown download page

### DIFF
--- a/src/downloader/uptodown.py
+++ b/src/downloader/uptodown.py
@@ -21,7 +21,7 @@ class UptoDown(Downloader):
         handle_request_response(r, page)
         soup = BeautifulSoup(r.text, bs4_parser)
         detail_download_button = soup.find("button", id="detail-download-button")
-        if "download-link-deeplink" in detail_download_button.get('onclick'):
+        if "download-link-deeplink" in detail_download_button.get("onclick"):
             page = f"{page}-x"
             r = requests.get(page, headers=request_header, allow_redirects=True, timeout=request_timeout)
             handle_request_response(r, page)

--- a/src/downloader/uptodown.py
+++ b/src/downloader/uptodown.py
@@ -21,6 +21,12 @@ class UptoDown(Downloader):
         handle_request_response(r, page)
         soup = BeautifulSoup(r.text, bs4_parser)
         detail_download_button = soup.find("button", id="detail-download-button")
+        if "download-link-deeplink" in detail_download_button.get('onclick'):
+            page = f"{page}-x"
+            r = requests.get(page, headers=request_header, allow_redirects=True, timeout=request_timeout)
+            handle_request_response(r, page)
+            soup = BeautifulSoup(r.text, bs4_parser)
+            detail_download_button = soup.find("button", id="detail-download-button")
 
         if not isinstance(detail_download_button, Tag):
             msg = f"Unable to download {app} from uptodown."
@@ -66,7 +72,7 @@ class UptoDown(Downloader):
 
             for item in json["data"]:
                 if item["version"] == version:
-                    download_url = f"{item["versionURL"]}-x"
+                    download_url = item["versionURL"]
                     version_found = True
                     break
 


### PR DESCRIPTION
### **User description**
Only expand page when download page encounters Uptodown App Store


___

### **PR Type**
Bug fix


___

### **Description**
- Fixed the extraction of download links from Uptodown by adding logic to handle pages with "download-link-deeplink" in the button's onclick attribute.
- Removed the unnecessary '-x' suffix from the version URL in the specific version method.
- Improved the robustness of the download link extraction process.



___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>uptodown.py</strong><dd><code>Fix and enhance Uptodown download link extraction logic</code>&nbsp; &nbsp; </dd></summary>
<hr>

src/downloader/uptodown.py

<li>Added logic to handle pages with "download-link-deeplink" in the <br>button's onclick attribute.<br> <li> Removed unnecessary '-x' suffix from the version URL.<br> <li> Improved handling of download link extraction for Uptodown.<br>


</details>


  </td>
  <td><a href="https://github.com/nikhilbadyal/docker-py-revanced/pull/590/files#diff-5fc51b26ebd6bfba6973761541fe04a8ccae4f8c625b63c72e918c861d308a77">+7/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**: Comment `/help "your question"` on any pull request to receive relevant information