### PR TITLE
🐛 Fix Uptodown download page

### DIFF
--- a/src/downloader/uptodown.py
+++ b/src/downloader/uptodown.py
@@ -21,6 +21,12 @@ class UptoDown(Downloader):
         handle_request_response(r, page)
         soup = BeautifulSoup(r.text, bs4_parser)
         detail_download_button = soup.find("button", id="detail-download-button")
+        if "download-link-deeplink" in detail_download_button.get("onclick"):
+            page = f"{page}-x"
+            r = requests.get(page, headers=request_header, allow_redirects=True, timeout=request_timeout)
+            handle_request_response(r, page)
+            soup = BeautifulSoup(r.text, bs4_parser)
+            detail_download_button = soup.find("button", id="detail-download-button")
 
         if not isinstance(detail_download_button, Tag):
             msg = f"Unable to download {app} from uptodown."


### PR DESCRIPTION
### **User description**
Only expand page when download page has Uptodown App Store


___

### **PR Type**
Bug fix


___

### **Description**
- Fixed an issue with extracting the download link from Uptodown pages by checking for a specific condition in the button's onclick attribute.
- Implemented a mechanism to reload the page with a modified URL when the condition is met, ensuring the correct download button is identified.



___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>uptodown.py</strong><dd><code>Fix download link extraction for Uptodown pages</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/downloader/uptodown.py

<li>Added a check for "download-link-deeplink" in the button's onclick <br>attribute.<br> <li> Modified the page URL and re-requested the page if the condition is <br>met.<br> <li> Ensured the download button is correctly identified after the page <br>reload.<br>


</details>


  </td>
  <td><a href="https://github.com/nikhilbadyal/docker-py-revanced/pull/591/files#diff-5fc51b26ebd6bfba6973761541fe04a8ccae4f8c625b63c72e918c861d308a77">+6/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**: Comment `/help "your question"` on any pull request to receive relevant information