### PR TITLE
Provide options arg along with patches to the cli

### DIFF
--- a/src/parser.py
+++ b/src/parser.py
@@ -23,7 +23,7 @@ class Parser(object):
     PATCHES_ARG = "-p"
     OUTPUT_ARG = "-o"
     KEYSTORE_ARG = "--keystore"
-    OPTIONS_ARG = "--legacy-options"
+    OPTIONS_ARG = "-O"
 
     def __init__(self: Self, patcher: Patches, config: RevancedConfig) -> None:
         self._PATCHES: list[str] = []
@@ -67,7 +67,7 @@ class Parser(object):
         if options:
             for opt in options:
                 pair = self.format_option(opt)
-                self._PATCHES[:0] = ["-O", pair]
+                self._PATCHES[:0] = [self.OPTIONS_ARG, pair]
         self._PATCHES[:0] = ["-e", name]
 
     def exclude(self: Self, name: str) -> None:
@@ -222,8 +222,6 @@ class Parser(object):
             app.get_output_file_name(),
             self.KEYSTORE_ARG,
             app.keystore_name,
-            # self.OPTIONS_ARG,
-            # app.options_file,
         ]
         args.append(exp)
         args[1::2] = map(self.config.temp_folder.joinpath, args[1::2])

--- a/src/patches_gen.py
+++ b/src/patches_gen.py
@@ -85,7 +85,7 @@ def convert_command_output_to_json(
         return result
 
     # Run the command
-    command = ["java", "-jar", jar_file_name, "list-patches", "-ipuv", patches_file]
+    command = ["java", "-jar", jar_file_name, "list-patches", "-ipuvo", patches_file]
     output = run_command_and_capture_output(command)
 
     parsed_data = parse_text_to_json(output)


### PR DESCRIPTION
### **User description**
- Added function to provide options along with respective patches
- Still using the apk/options.json to set/modify options by the user
- There's an issue I noticed, that some options arg are applied to rest of the enabled patches who have none options provided. It's from the revanced-cli side due to how arguments are parsed


___

### **PR Type**
Enhancement, Bug fix


___

### **Description**
- Added support for including options with patches in the CLI.

- Fixed issue where options were not generated in `patches.json`.

- Introduced `include_with_options` and `fetch_patch_options` methods for better patch handling.

- Improved error handling for missing or invalid options files.


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>parser.py</strong><dd><code>Add methods for handling patch options</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/parser.py

<li>Added <code>include_with_options</code> method to handle patches with options.<br> <li> Introduced <code>fetch_patch_options</code> to retrieve patch-specific options.<br> <li> Enhanced <code>include_exclude_patch</code> to process options from a JSON file.<br> <li> Improved error handling for missing or invalid options files.


</details>


  </td>
  <td><a href="https://github.com/nikhilbadyal/docker-py-revanced/pull/629/files#diff-f3801dd467fe03200aeee0231f8d75c571a23d688f3372e6a841565a3c46f69f">+66/-8</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>patches_gen.py</strong><dd><code>Update CLI command to include options argument</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/patches_gen.py

- Updated CLI command to include options argument (`-ipuvo`).


</details>


  </td>
  <td><a href="https://github.com/nikhilbadyal/docker-py-revanced/pull/629/files#diff-341fcccf57984b45415f73ba02f4726982a87916cdeaf24db51569805f7fa8a0">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about Qodo Merge usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>