### PR TITLE
✨ Multi Source patch

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ You can use any of the following methods to build.
 
         </details>
 
-     5. If the building process is successful, you’ll get your APKs in the<br>
+     5. If the building process is successful, you'll get your APKs in the<br>
         <img src="https://i.imgur.com/S5d7qAO.png" width="700" style="left">
      6. Make sure to do below steps once in a while(daily or weekly) to keep the builder bug free.<br>
         <img src="https://i.imgur.com/CbdH7vM.png" width="700" style="left">
@@ -134,20 +134,20 @@ You can use any of the following methods to build.
 `*` - Can be overridden for individual app.
 ### App Level Config
 
-| Env Name                                                      |                                               Description                                               | Default                        |
-|:--------------------------------------------------------------|:-------------------------------------------------------------------------------------------------------:|:-------------------------------|
-| [~~**APP_NAME**_CLI_DL~~](#global-resources)                  |                     DL for CLI to be used for patching **APP_NAME**.(Disabled Temp)                     | GLOBAL_CLI_DL                  |
-| [**APP_NAME**_PATCHES_DL](#global-resources)                  |                          DL for Patches to be used for patching **APP_NAME**.                           | GLOBAL_PATCHES_DL              |
-| [**APP_NAME**_SPACE_FORMATTED_PATCHES](#global-resources)     |                          Whether patches are space formatted.   **APP_NAME**.                           | GLOBAL_SPACE_FORMATTED_PATCHES |
-| [**APP_NAME**_KEYSTORE_FILE_NAME](#global-keystore-file-name) |                              Key file to be used for signing **APP_NAME**.                              | GLOBAL_KEYSTORE_FILE_NAME      |
-| [**APP_NAME**_OLD_KEY](#global-keystore-file-name)            |      Whether key used was generated with cli > v4(new) <br/><br/>**APP_NAME**.      <br/>   <br/>       | GLOBAL_OLK_KEY                 |
-| [**APP_NAME**_ARCHS_TO_BUILD](#global-archs-to-build)         |                                Arch to keep in the patched **APP_NAME**.                                | GLOBAL_ARCHS_TO_BUILD          |
-| [**APP_NAME**_EXCLUDE_PATCH**](#custom-exclude-patching)      |                            Patches to exclude while patching  **APP_NAME**.                             | []                             |
-| [**APP_NAME**_INCLUDE_PATCH**](#custom-include-patching)      |                            Patches to include while patching  **APP_NAME**.                             | []                             |
-| [**APP_NAME**_VERSION](#app-version)                          |                                Version to use for download for patching.                                | Recommended by patch resources |
-| [**APP_NAME**_PACKAGE_NAME***](#any-patch-apps)               |                                  Package name of the app to be patched                                  | None                           |
-| [**APP_NAME**_DL_SOURCE***](#any-patch-apps)                  |                            Download source of any of the supported scrapper                             | None                           |
-| [**APP_NAME**_DL***](#app-dl)                                 |                                   Direct download Link for clean apk                                    | None                           |
+| Env Name                                                      |                                             Description                                              | Default                        |
+|:--------------------------------------------------------------|:----------------------------------------------------------------------------------------------------:|:-------------------------------|
+| [~~**APP_NAME**_CLI_DL~~](#global-resources)                  |                   DL for CLI to be used for patching **APP_NAME**.(Disabled Temp)                    | GLOBAL_CLI_DL                  |
+| [**APP_NAME**_PATCHES_DL](#global-resources)                  | DL for Patches to be used for patching **APP_NAME**. Supports multiple bundles via comma separation. | GLOBAL_PATCHES_DL              |
+| [**APP_NAME**_SPACE_FORMATTED_PATCHES](#global-resources)     |                         Whether patches are space formatted.   **APP_NAME**.                         | GLOBAL_SPACE_FORMATTED_PATCHES |
+| [**APP_NAME**_KEYSTORE_FILE_NAME](#global-keystore-file-name) |                            Key file to be used for signing **APP_NAME**.                             | GLOBAL_KEYSTORE_FILE_NAME      |
+| [**APP_NAME**_OLD_KEY](#global-keystore-file-name)            |     Whether key used was generated with cli > v4(new) <br/><br/>**APP_NAME**.      <br/>   <br/>     | GLOBAL_OLK_KEY                 |
+| [**APP_NAME**_ARCHS_TO_BUILD](#global-archs-to-build)         |                              Arch to keep in the patched **APP_NAME**.                               | GLOBAL_ARCHS_TO_BUILD          |
+| [**APP_NAME**_EXCLUDE_PATCH**](#custom-exclude-patching)      |                           Patches to exclude while patching  **APP_NAME**.                           | []                             |
+| [**APP_NAME**_INCLUDE_PATCH**](#custom-include-patching)      |                           Patches to include while patching  **APP_NAME**.                           | []                             |
+| [**APP_NAME**_VERSION](#app-version)                          |                              Version to use for download for patching.                               | Recommended by patch resources |
+| [**APP_NAME**_PACKAGE_NAME***](#any-patch-apps)               |                                Package name of the app to be patched                                 | None                           |
+| [**APP_NAME**_DL_SOURCE***](#any-patch-apps)                  |                           Download source of any of the supported scrapper                           | None                           |
+| [**APP_NAME**_DL***](#app-dl)                                 |                                  Direct download Link for clean apk                                  | None                           |
 
 `**` - By default all patches for a given app are included.<br>
 `**` - Can be used to included universal patch.<br>
@@ -308,10 +308,17 @@ You can use any of the following methods to build.
    ```
    With the config tool will try to patch YouTube with resources from inotia00 while other global resource will used
    for patching other apps.<br>
+
+      **Multi-Patching Support**: You can now use multiple patch bundles from different creators for the same app:
+   ```dotenv
+    # Comma-separated URLs
+    YOUTUBE_PATCHES_DL=https://github.com/ReVanced/revanced-patches,https://github.com/indrastorm/Dropped-patches
+   ```
+   The tool will download all specified patch bundles and apply them together using the ReVanced CLI's multiple `-p` argument support.<br>
    If you have want to provide resource locally in the apks folder. You can specify that by mentioning filename
    prefixed with `local://`.<br>
-   *Note* - The link provided must be DLs. Unless they are from GitHub.<br>
-   *Note* - If your patches resource are available on GitHub and you want to select latest resource without excluding
+   _Note_ - The link provided must be DLs. Unless they are from GitHub.<br>
+   _Note_ - If your patches resource are available on GitHub and you want to select latest resource without excluding
     pre-release you can add `latest-prerelease` to the URL.
     Example:
    ```dotenv
@@ -323,7 +330,7 @@ You can use any of the following methods to build.
    ```
    For above example tool while selecting latest patches will exclude any pre-release/beta ie. will consider only
     stable releases..<br>
-   *Note* - Some of the patch source like inotia00 still provides **-** separated patches while revanced shifted to
+   _Note_ - Some of the patch source like inotia00 still provides **-** separated patches while revanced shifted to
    Space formatted patches. Use `SPACE_FORMATTED_PATCHES` to define the type of patches.
 
 8. <a id="global-keystore-file-name"></a>If you don't want to use default keystore. You can provide your own by
@@ -371,7 +378,7 @@ You can use any of the following methods to build.
     ```dotenv
      YOUTUBE_ARCHS_TO_BUILD=arm64-v8a,armeabi-v7a
     ```
-    *Note* -
+    _Note_ -
     1. Possible values are: `armeabi-v7a`,`x86`,`x86_64`,`arm64-v8a`
     2. Make sure the patching resource(CLI) support this feature.
 11. <a id="extra-files"></a>If you want to include any extra file to the Github upload. Set comma arguments

--- a/src/app.py
+++ b/src/app.py
@@ -31,10 +31,17 @@ class APP(object):
         self.app_version = config.env.str(f"{app_name}_VERSION".upper(), None)
         self.experiment = False
         self.cli_dl = config.env.str(f"{app_name}_CLI_DL".upper(), config.global_cli_dl)
-        self.patches_dl = config.env.str(f"{app_name}_PATCHES_DL".upper(), config.global_patches_dl)
+
+        # Support multiple patch bundles via comma-separated URLs
+        patches_dl_raw = config.env.str(f"{app_name}_PATCHES_DL".upper(), config.global_patches_dl)
+        self.patches_dl_list = [url.strip() for url in patches_dl_raw.split(",") if url.strip()]
+        # Keep backward compatibility
+        self.patches_dl = patches_dl_raw
+
         self.exclude_request: list[str] = config.env.list(f"{app_name}_EXCLUDE_PATCH".upper(), [])
         self.include_request: list[str] = config.env.list(f"{app_name}_INCLUDE_PATCH".upper(), [])
         self.resource: dict[str, dict[str, str]] = {}
+        self.patch_bundles: list[dict[str, str]] = []  # Store multiple patch bundles
         self.no_of_patches: int = 0
         self.keystore_name = config.env.str(f"{app_name}_KEYSTORE_FILE_NAME".upper(), config.global_keystore_name)
         self.archs_to_build = config.env.list(f"{app_name}_ARCHS_TO_BUILD".upper(), config.global_archs_to_build)
@@ -113,18 +120,18 @@ class APP(object):
         ----------
         url : str
             The `url` parameter is a string that represents the URL of the resource you want to download.
-        It can be a URL from GitHub or a local file URL.
+            It can be a URL from GitHub or a local file URL.
         config : RevancedConfig
             The `config` parameter is an instance of the `RevancedConfig` class. It is used to provide
-        configuration settings for the download process.
+            configuration settings for the download process.
         assets_filter : str
             The `assets_filter` parameter is a string that is used to filter the assets to be downloaded
-        from a GitHub repository. It is used when the `url` parameter starts with "https://github". The
-        `assets_filter` string is matched against the names of the assets in the repository, and only
-        file_name : str
+            from a GitHub repository. It is used when the `url` parameter starts with "https://github". The
+            `assets_filter` string is matched against the names of the assets in the repository, and only
+            file_name : str
             The `file_name` parameter is a string that represents the name of the file that will be
-        downloaded. If no value is provided for `file_name`, the function will generate a filename based
-        on the URL of the file being downloaded.
+            downloaded. If no value is provided for `file_name`, the function will generate a filename based
+            on the URL of the file being downloaded.
 
         Returns
         -------
@@ -148,6 +155,58 @@ class APP(object):
         Downloader(config).direct_download(url, file_name)
         return tag, file_name
 
+    def _setup_download_tasks(self: Self) -> list[tuple[str, str, None, str]]:
+        """Setup download tasks for CLI and patch bundles."""
+        download_tasks = [
+            ("cli", self.cli_dl, None, ".*jar"),
+        ]
+
+        # Download multiple patch bundles
+        for i, patches_url in enumerate(self.patches_dl_list):
+            bundle_name = f"patches_{i}" if len(self.patches_dl_list) > 1 else "patches"
+            download_tasks.append((bundle_name, patches_url, None, ".*rvp"))
+
+        return download_tasks
+
+    def _handle_cached_resource(self: Self, resource_name: str, tag: str, file_name: str) -> None:
+        """Handle cached resource and update appropriate data structures."""
+        if resource_name.startswith("patches"):
+            self.patch_bundles.append(
+                {
+                    "name": resource_name,
+                    "file_name": file_name,
+                    "version": tag,
+                },
+            )
+            # Keep backward compatibility for single bundle
+            if resource_name == "patches" or len(self.patches_dl_list) == 1:
+                self.resource["patches"] = {
+                    "file_name": file_name,
+                    "version": tag,
+                }
+        else:
+            self.resource[resource_name] = {
+                "file_name": file_name,
+                "version": tag,
+            }
+
+    def _handle_downloaded_resource(
+        self: Self,
+        resource_name: str,
+        tag: str,
+        file_name: str,
+        download_tasks: list[tuple[str, str, RevancedConfig, str]],
+        resource_cache: dict[str, tuple[str, str]],
+    ) -> None:
+        """Handle newly downloaded resource and update cache."""
+        self._handle_cached_resource(resource_name, tag, file_name)
+
+        # Update cache for the corresponding URL
+        for task_name, task_url, _, _ in download_tasks:
+            if task_name == resource_name:
+                resource_cache[task_url.strip()] = (tag, file_name)
+                break
+
     def download_patch_resources(
         self: Self,
         config: RevancedConfig,
@@ -159,14 +218,15 @@ class APP(object):
         ----------
         config : RevancedConfig
             The `config` parameter is an instance of the `RevancedConfig` class. It is used to provide
-        configuration settings for the resource download tasks.
+             configuration settings for the resource download tasks.
         resource_cache: dict[str, tuple[str, str]]
         """
         logger.info("Downloading resources for patching.")
 
-        download_tasks = [
-            ("cli", self.cli_dl, config, ".*jar"),
-            ("patches", self.patches_dl, config, ".*rvp"),
+        base_tasks = self._setup_download_tasks()
+        # Update download tasks with config
+        download_tasks: list[tuple[str, str, RevancedConfig, str]] = [
+            (name, url, config, filter_pattern) for name, url, _, filter_pattern in base_tasks
         ]
 
         with ThreadPoolExecutor(1) as executor:
@@ -177,10 +237,7 @@ class APP(object):
                 if url in resource_cache:
                     logger.info(f"Skipping {resource_name} download, using cached resource: {url}")
                     tag, file_name = resource_cache[url]
-                    self.resource[resource_name] = {
-                        "file_name": file_name,
-                        "version": tag,
-                    }
+                    self._handle_cached_resource(resource_name, tag, file_name)
                     continue
 
                 futures[resource_name] = executor.submit(self.download, url, cfg, assets_filter)
@@ -190,14 +247,7 @@ class APP(object):
             for resource_name, future in futures.items():
                 try:
                     tag, file_name = future.result()
-                    self.resource[resource_name] = {
-                        "file_name": file_name,
-                        "version": tag,
-                    }
-                    resource_cache[download_tasks[["cli", "patches"].index(resource_name)][1].strip()] = (
-                        tag,
-                        file_name,
-                    )
+                    self._handle_downloaded_resource(resource_name, tag, file_name, download_tasks, resource_cache)
                 except BuilderError as e:
                     msg = f"Failed to download {resource_name} resource."
                     raise PatchingFailedError(msg) from e

--- a/src/downloader/github.py
+++ b/src/downloader/github.py
@@ -51,7 +51,9 @@ class Github(Downloader):
         """Extract repo owner and url from github url."""
         parsed_url = urlparse(url)
         path_segments = parsed_url.path.strip("/").split("/")
-
+        if len(path_segments) < 2:
+            msg = f"Invalid GitHub URL format: {url}"
+            raise DownloadError(msg)
         github_repo_owner = path_segments[0]
         github_repo_name = path_segments[1]
         tag_position = 3

--- a/src/exceptions.py
+++ b/src/exceptions.py
@@ -130,4 +130,4 @@ class PatchesJsonLoadError(BuilderError):
     def __str__(self: Self) -> str:
         """Exception message."""
         base_message = super().__str__()
-        return f"Message - {base_message} Url - {self.file_name}"
+        return f"Message - {base_message} File - {self.file_name}"


### PR DESCRIPTION
Fixes #550 


Summary by Sourcery

Add multi-source patch bundle support by allowing comma-separated URLs, downloading and merging multiple patch bundles while preserving single-bundle compatibility.

New Features:

    Support multiple patch bundles via comma-separated URLs in the APP_PATCHES_DL environment variable
    Pass multiple patch bundles to the ReVanced CLI using repeated -b flags

Enhancements:

    Add setup and handler methods to orchestrate download tasks and update resource cache for multiple bundles
    Maintain backward compatibility for single-bundle workflows
    Deduplicate patches when merging multiple bundles

Documentation:

    Update README to document multi-patch bundle support and APP_PATCHES_DL usage

## Summary by Sourcery

Enable multi-source patch bundle support by allowing comma-separated patch URLs, downloading and merging multiple bundles, and passing them to the CLI with backward compatibility for single-bundle workflows

New Features:
- Support specifying multiple patch bundles via comma-separated URLs in APP_PATCHES_DL
- Pass multiple patch bundles to the ReVanced CLI using repeated -b flags

Enhancements:
- Add download orchestration methods to handle multiple patch bundles and maintain backward compatibility
- Merge and deduplicate patches across multiple bundles during patch fetching

Documentation:
- Update README to document multi-patch bundle support and comma-separated APP_PATCHES_DL usage