### PR TITLE
fix(apkeep): cache downloads from apkeep sources with package name and version

### DIFF
--- a/src/app.py
+++ b/src/app.py
@@ -106,9 +106,10 @@ class APP(object):
 
     def get_download_cache_key(self: Self) -> tuple[str, str]:
         """Returns a unique cache key for the app."""
+        version = self.app_version or "latest"
         if self.download_source == APKEEP:
-            return (self.download_source, f"{self.package_name}@{self.app_version}")
-        return (self.download_source, self.app_version or "latest")
+            return (self.download_source, f"{self.package_name}@{version}")
+        return (self.download_source, version)
 
     def get_output_file_name(self: Self) -> str:
         """The function returns a string representing the output file name.


### PR DESCRIPTION
### **User description**
Fixes #676


___

### **PR Type**
Bug fix


___

### **Description**
- Fix APK download caching for apkeep sources

- Use package name and version for cache keys

- Improve cache key generation logic

- Move cache check outside lock for better performance


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Download Request"] --> B["Generate Cache Key"]
  B --> C{"Cache Hit?"}
  C -->|Yes| D["Reuse Cached APK"]
  C -->|No| E["Acquire Lock"]
  E --> F["Download APK"]
  F --> G["Store in Cache"]
  B --> H["get_download_cache_key()"]
  H --> I{"APKEEP Source?"}
  I -->|Yes| J["package_name@version"]
  I -->|No| K["source + version"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>app.py</strong><dd><code>Improve APK download caching mechanism</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/app.py

<ul><li>Import <code>APKEEP</code> constant from downloader sources<br> <li> Replace direct cache key creation with <code>get_download_cache_key()</code> method<br> <li> Move initial cache check outside the lock for performance<br> <li> Add new method to generate cache keys based on source type</ul>


</details>


  </td>
  <td><a href="https://github.com/nikhilbadyal/docker-py-revanced/pull/678/files#diff-04791d82dd15fdd480f084d7ef65a10789fa5012cb7935f76080763444d48a00">+13/-7</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

