### PR TITLE
fix(check_updates): executing `DRY_RUN` branch when set to non-empty string

### DIFF
--- a/src/manager/github.py
+++ b/src/manager/github.py
@@ -1,7 +1,6 @@
 """Github Manager."""
 
 import json
-import os
 import urllib.request
 from pathlib import Path
 from typing import Self
@@ -22,10 +21,11 @@ class GitHubManager(ReleaseManager):
             branch_name=branch_name,
             updates_file=updates_file,
         )
+        self.is_dry_run = env.bool("DRY_RUN", False)
 
     def get_last_version(self: Self, app: APP, resource_name: str) -> str | list[str]:
         """Get last patched version."""
-        if os.getenv("DRY_RUN", default=None):
+        if self.is_dry_run:
             with Path(updates_file).open() as url:
                 data = json.load(url)
         else:
@@ -39,7 +39,7 @@ class GitHubManager(ReleaseManager):
 
     def get_last_version_source(self: Self, app: APP, resource_name: str) -> str | list[str]:
         """Get last patched version."""
-        if os.getenv("DRY_RUN", default=None):
+        if self.is_dry_run:
             with Path(updates_file).open() as url:
                 data = json.load(url)
         else:


### PR DESCRIPTION
### **User description**
- The branch would execute even when set to `False`.


___

### **PR Type**
Bug fix


___

### **Description**
- Replace `os.getenv()` with proper boolean environment variable parsing

- Store `DRY_RUN` as instance variable during initialization

- Fix incorrect truthiness check that treated non-empty strings as truthy

- Remove unused `os` module import


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["os.getenv returns string or None"] -->|"Incorrect: truthy check"| B["Always executes DRY_RUN branch"]
  C["env.bool parses to boolean"] -->|"Correct: boolean check"| D["Executes correct branch"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>github.py</strong><dd><code>Fix DRY_RUN boolean environment variable handling</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/manager/github.py

<ul><li>Removed unused <code>os</code> module import<br> <li> Added <code>self.is_dry_run</code> instance variable initialized with <br><code>env.bool("DRY_RUN", False)</code> in <code>__init__</code><br> <li> Replaced two <code>os.getenv("DRY_RUN", default=None)</code> calls with <br><code>self.is_dry_run</code> boolean check in <code>get_last_version()</code> and <br><code>get_last_version_source()</code> methods<br> <li> Fixed boolean evaluation logic to properly handle environment variable <br>as boolean instead of string</ul>


</details>


  </td>
  <td><a href="https://github.com/nikhilbadyal/docker-py-revanced/pull/685/files#diff-d2620332d711f34f510593d114fa18398c890247eb36179d789a341fe870f041">+3/-3</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

