### PR TITLE
Integrate cloudscraper to bypass Cloudflare for APKMirror requests

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,5 @@
 beautifulsoup4==4.13.4
+cloudscraper==1.2.71
 environs==14.1.1
 google-play-scraper==1.2.7
 lastversion==3.5.7

--- a/src/downloader/apkmirror.py
+++ b/src/downloader/apkmirror.py
@@ -1,8 +1,7 @@
 """Downloader Class."""
 
-from typing import Any, Self
+from typing import Any, Self, cast
 
-import requests
 from bs4 import BeautifulSoup, Tag
 from loguru import logger
 
@@ -10,14 +9,27 @@ from src.app import APP
 from src.downloader.download import Downloader
 from src.downloader.sources import APK_MIRROR_BASE_URL
 from src.exceptions import APKMirrorAPKDownloadError, ScrapingError
-from src.utils import bs4_parser, contains_any_word, handle_request_response, request_header, request_timeout, slugify
+from src.utils import (
+    apkmirror_scraper,
+    bs4_parser,
+    contains_any_word,
+    handle_request_response,
+    request_timeout,
+    slugify,
+)
 
 
 class ApkMirror(Downloader):
     """Files downloader."""
 
     def _extract_force_download_link(self: Self, link: str, app: str) -> tuple[str, str]:
-        """Extract force download link."""
+        """Extract force download link.
+
+        The actual download.php file endpoint is also behind Cloudflare, so we
+        must use apkmirror_scraper (instead of the plain requests session) and
+        pass the download page URL as a Referer header — exactly what the
+        twitter-apk reference implementation does — to satisfy Cloudflare checks.
+        """
         link_page_source = self._extract_source(link)
         notes_divs = self._extracted_search_source_div(link_page_source, "tab-pane")
         apk_type = self._extracted_search_source_div(link_page_source, "apkm-badge").get_text()
@@ -26,8 +38,15 @@ class ApkMirror(Downloader):
         for possible_link in possible_links:
             if possible_link.get("href") and "download.php?id=" in possible_link.get("href"):
                 file_name = f"{app}.{extension}"
-                self._download(APK_MIRROR_BASE_URL + possible_link["href"], file_name)
-                return file_name, APK_MIRROR_BASE_URL + possible_link["href"]
+                download_url = APK_MIRROR_BASE_URL + possible_link["href"]
+                # Use cloudscraper + Referer so Cloudflare allows the binary download
+                self._download(
+                    download_url,
+                    file_name,
+                    http_session=apkmirror_scraper,
+                    extra_headers={"Referer": link},
+                )
+                return file_name, download_url
         msg = f"Unable to extract force download for {app}"
         raise APKMirrorAPKDownloadError(msg, url=link)
 
@@ -77,10 +96,17 @@ class ApkMirror(Downloader):
 
     @staticmethod
     def _extract_source(url: str) -> str:
-        """Extracts the source from the url incase of reuse."""
-        response = requests.get(url, headers=request_header, timeout=request_timeout)
+        """Extracts the source from the url incase of reuse.
+
+        Uses cloudscraper instead of plain requests because APKMirror is protected
+        by Cloudflare. Plain requests.get returns HTTP 403 with a JS challenge page
+        ("Just a moment...") in CI environments. cloudscraper transparently handles
+        those challenges and returns the real page HTML.
+        """
+        response = apkmirror_scraper.get(url, timeout=request_timeout)
         handle_request_response(response, url)
-        return response.text
+        # cloudscraper's .text is typed as Any; cast to str to satisfy mypy
+        return cast("str", response.text)
 
     @staticmethod
     def _extracted_search_source_div(source: str, search_class: str) -> Tag:

--- a/src/downloader/download.py
+++ b/src/downloader/download.py
@@ -8,6 +8,7 @@ from time import perf_counter
 from typing import Any, Self
 
 from loguru import logger
+from requests import Session
 from tqdm import tqdm
 
 from src.app import APP
@@ -27,7 +28,29 @@ class Downloader(object):
         self.global_archs_priority: Any = None
         self.app_version: Any = None
 
-    def _download(self: Self, url: str, file_name: str) -> None:
+    def _download(
+        self: Self,
+        url: str,
+        file_name: str,
+        http_session: Session | None = None,
+        extra_headers: dict[str, str] | None = None,
+    ) -> None:
+        """Download a file from url to the configured temp folder.
+
+        Parameters
+        ----------
+        url : str
+            URL to download from.
+        file_name : str
+            Name of the file to save.
+        http_session : Session | None
+            Optional HTTP session to use for the request. Defaults to the shared
+            plain requests.Session. Pass apkmirror_scraper for APKMirror URLs so
+            that Cloudflare challenges are solved transparently.
+        extra_headers : dict[str, str] | None
+            Optional additional headers merged on top of the default headers (e.g.
+            a Referer for APKMirror file downloads to satisfy Cloudflare checks).
+        """
         if not url:
             msg = "No url provided to download"
             raise DownloadError(msg)
@@ -37,11 +60,21 @@ class Downloader(object):
         logger.info(f"Trying to download {file_name} from {url}")
         self._QUEUE_LENGTH += 1
         start = perf_counter()
-        headers = {}
+
+        # Use the caller-supplied session (e.g. cloudscraper for APKMirror) or
+        # fall back to the module-level plain requests session.
+        effective_session = http_session if http_session is not None else session
+
+        headers: dict[str, str] = {}
         if self.config.personal_access_token and "github" in url:
             logger.debug("Using personal access token")
             headers["Authorization"] = f"token {self.config.personal_access_token}"
-        response = session.get(
+
+        # Merge any caller-supplied extra headers (e.g. Referer for APKMirror)
+        if extra_headers:
+            headers.update(extra_headers)
+
+        response = effective_session.get(
             url,
             stream=True,
             headers=headers,

--- a/src/utils.py
+++ b/src/utils.py
@@ -13,6 +13,7 @@ from pathlib import Path
 from typing import TYPE_CHECKING, Any
 from zoneinfo import ZoneInfo
 
+import cloudscraper
 import requests
 from environs import Env
 from loguru import logger
@@ -44,6 +45,13 @@ changelog_json_file = "changelog.json"
 request_timeout = 60
 session = Session()
 session.headers["User-Agent"] = request_header["User-Agent"]
+
+# Singleton cloudscraper session used for all APKMirror requests.
+# APKMirror is protected by Cloudflare, which blocks plain requests with a 403
+# "Just a moment..." challenge page. cloudscraper transparently solves those
+# JS/cookie challenges and returns the real HTML response.
+apkmirror_scraper = cloudscraper.create_scraper()
+apkmirror_scraper.headers.update({"User-Agent": request_header["User-Agent"]})
 updates_file = "updates.json"
 updates_file_url = "https://raw.githubusercontent.com/{github_repository}/{branch_name}/{updates_file}"
 changelogs: dict[str, dict[str, str]] = {}


### PR DESCRIPTION
…are protection

## Summary by Sourcery

Use a dedicated Cloudflare-aware HTTP client for APKMirror downloads to avoid 403 challenge pages and ensure reliable scraping.

Bug Fixes:
- Prevent APKMirror downloads from failing with HTTP 403 when Cloudflare presents a JS challenge page.

Enhancements:
- Introduce a shared cloudscraper-based client for all APKMirror requests and integrate it into the APKMirror downloader implementation.

Build:
- Add cloudscraper as a runtime dependency for handling Cloudflare-protected APKMirror requests.