### PR TITLE
feat: migrate cli args from string to list of strings

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -8,7 +8,7 @@ GLOBAL_CLI_ARGSF=revanced-cli
 # Optional global list-patches argument overrides as KEY=value pairs
 # GLOBAL_CLI_LPARGS="CMD=list-patches INDEX=-i PACKAGES=-p UNIVERSAL=-u VERSIONS=-v OPTIONS=-o PATCHES=__POSITIONAL__ PATCHES_POST="
 # Optional global patch argument overrides as KEY=value pairs
-# GLOBAL_CLI_PARGS="CMD=patch PATCHES=-p PATCHES_POST= ENABLED=-e DISABLED=-d OPTIONS=-O PURGE=--purge KEYSTORE=--keystore KEYSTORE_ENTRY_ALIAS=--keystore-entry-alias=alias KEYSTORE_ENTRY_PASSWORD=--keystore-entry-password=ReVanced KEYSTORE_PASSWORD=--keystore-password=ReVanced EXCLUSIVE=--exclusive APK=__POSITIONAL__ OUTPUT=-o FORCE=--force RIP_LIB=--rip-lib"
+# GLOBAL_CLI_PARGS="CMD=patch PATCHES=-p PATCHES_POST= ENABLED=-e DISABLED=-d OPTIONS=-O PURGE=--purge KEYSTORE=--keystore KEYSTORE_OLD='--keystore-entry-alias=alias --keystore-entry-password=ReVanced --keystore-password=ReVanced' EXCLUSIVE=--exclusive APK=__POSITIONAL__ OUTPUT=-o FORCE=--force RIP_LIB=--rip-lib"
 
 #Example
 EXISTING_DOWNLOADED_APKS=twitter

--- a/README.md
+++ b/README.md
@@ -352,24 +352,24 @@ You can use any of the following methods to build.
    This builder now supports multiple CLI syntax families and key-value override maps.
    ```dotenv
     # Default profile (recommended today)
-    GLOBAL_CLI_ARGSF=revanced-cli
+    GLOBAL_CLI_ARGSF=revanced-cli-v6
    ```
    Built-in profile values:
-   - `revanced-cli` (default, v5-style list-patches positional patch files)
-   - `revanced-cli-v6` (v6-style list-patches requires `-p/--patches`)
+   - `revanced-cli` (v5-style list-patches positional patch files)
+   - `revanced-cli-v6` (default, v6-style list-patches requires `-p/--patches`)
    - `morphe-cli` (morphe-style list-patches requires `--patches`)
 
    Override maps use unordered `KEY=value` pairs in a single string:
    ```dotenv
     GLOBAL_CLI_LPARGS="CMD=list-patches INDEX=-i PACKAGES=-p UNIVERSAL=-u VERSIONS=-v OPTIONS=-o PATCHES=__POSITIONAL__ PATCHES_POST="
-    GLOBAL_CLI_PARGS="CMD=patch PATCHES=-p PATCHES_POST= ENABLED=-e DISABLED=-d OPTIONS=-O PURGE=--purge KEYSTORE=--keystore KEYSTORE_ENTRY_ALIAS=--keystore-entry-alias=alias KEYSTORE_ENTRY_PASSWORD=--keystore-entry-password=ReVanced KEYSTORE_PASSWORD=--keystore-password=ReVanced EXCLUSIVE=--exclusive APK=__POSITIONAL__ OUTPUT=-o FORCE=--force RIP_LIB=--rip-lib"
+    GLOBAL_CLI_PARGS="CMD=patch PATCHES=-p PATCHES_POST= ENABLED=-e DISABLED=-d OPTIONS=-O PURGE=--purge KEYSTORE=--keystore KEYSTORE_OLD='--keystore-entry-alias=alias --keystore-entry-password=ReVanced --keystore-password=ReVanced' EXCLUSIVE=--exclusive APK=__POSITIONAL__ OUTPUT=-o FORCE=--force RIP_LIB=--rip-lib"
    ```
    `PATCHES_POST` is an optional companion argument appended after every patch bundle (used by ReVanced v6 with `-b`).
    App-level overrides are also supported and take precedence:
    ```dotenv
     YOUTUBE_CLI_ARGSF=morphe-cli
     YOUTUBE_CLI_LPARGS="PATCHES=--patches"
-    YOUTUBE_CLI_PARGS="PATCHES=-p STRIPLIBS=--striplibs"
+    YOUTUBE_CLI_PARGS="PATCHES=-p STRIPLIBS=--striplibs FORCE='--force --continue-on-error'"
    ```
 
    Example migration to ReVanced v6 syntax:

--- a/src/cli_args.py
+++ b/src/cli_args.py
@@ -42,9 +42,7 @@ PATCH_KEYS: Final[set[str]] = {
     "EXCLUSIVE",
     "FORCE",
     "KEYSTORE",
-    "KEYSTORE_ENTRY_ALIAS",
-    "KEYSTORE_ENTRY_PASSWORD",
-    "KEYSTORE_PASSWORD",
+    "KEYSTORE_OLD",
     "OPTIONS",
     "OUTPUT",
     "PATCHES",
@@ -55,42 +53,44 @@ PATCH_KEYS: Final[set[str]] = {
 }
 
 # These defaults intentionally match the existing builder behavior for current stable users.
-DEFAULT_LIST_PATCHES_ARGS: Final[dict[str, str]] = {
-    "CMD": "list-patches",
-    "DESCRIPTIONS": "",
-    "FILTER_PACKAGE_NAME": "",
-    "INDEX": "-i",
-    "OPTIONS": "-o",
-    "PACKAGES": "-p",
-    "PATCHES": POSITIONAL_ARG,
-    "PATCHES_POST": "",
-    "UNIVERSAL": "-u",
-    "VERSIONS": "-v",
+DEFAULT_LIST_PATCHES_ARGS: Final[dict[str, list[str]]] = {
+    "CMD": ["list-patches"],
+    "DESCRIPTIONS": [""],
+    "FILTER_PACKAGE_NAME": [""],
+    "INDEX": ["-i"],
+    "OPTIONS": ["-o"],
+    "PACKAGES": ["-p"],
+    "PATCHES": [POSITIONAL_ARG],
+    "PATCHES_POST": [""],
+    "UNIVERSAL": ["-u"],
+    "VERSIONS": ["-v"],
 }
 
 # These defaults intentionally match the existing patch invocation and keep old-key signing behavior compatible.
-DEFAULT_PATCH_ARGS: Final[dict[str, str]] = {
-    "APK": POSITIONAL_ARG,
-    "CMD": "patch",
-    "DISABLED": "-d",
-    "ENABLED": "-e",
-    "EXCLUSIVE": "--exclusive",
-    "FORCE": "--force",
-    "KEYSTORE": "--keystore",
-    "KEYSTORE_ENTRY_ALIAS": KEYSTORE_ALIAS_ARG,
-    "KEYSTORE_ENTRY_PASSWORD": KEYSTORE_ENTRY_PASSWORD_ARG,
-    "KEYSTORE_PASSWORD": KEYSTORE_PASSWORD_ARG,
-    "OPTIONS": "-O",
-    "OUTPUT": "-o",
-    "PATCHES": "-p",
-    "PATCHES_POST": "",
-    "PURGE": "--purge",
-    "RIP_LIB": "--rip-lib",
-    "STRIPLIBS": "",
+DEFAULT_PATCH_ARGS: Final[dict[str, list[str]]] = {
+    "APK": [POSITIONAL_ARG],
+    "CMD": ["patch"],
+    "DISABLED": ["-d"],
+    "ENABLED": ["-e"],
+    "EXCLUSIVE": ["--exclusive"],
+    "FORCE": ["--force"],
+    "KEYSTORE": ["--keystore"],
+    "KEYSTORE_OLD": [
+        KEYSTORE_ALIAS_ARG,
+        KEYSTORE_ENTRY_PASSWORD_ARG,
+        KEYSTORE_PASSWORD_ARG,
+    ],
+    "OPTIONS": ["-O"],
+    "OUTPUT": ["-o"],
+    "PATCHES": ["-p"],
+    "PATCHES_POST": [""],
+    "PURGE": ["--purge"],
+    "RIP_LIB": ["--rip-lib"],
+    "STRIPLIBS": [""],
 }
 
 # Profile map centralizes known CLI families so users can switch format with one env variable.
-CLI_PROFILES: Final[dict[str, dict[str, dict[str, str]]]] = {
+CLI_PROFILES: Final[dict[str, dict[str, dict[str, list[str]]]]] = {
     "revanced-cli": {
         "list_patches": deepcopy(DEFAULT_LIST_PATCHES_ARGS),
         "patch": deepcopy(DEFAULT_PATCH_ARGS),
@@ -98,87 +98,91 @@ CLI_PROFILES: Final[dict[str, dict[str, dict[str, str]]]] = {
     "revanced-cli-v6": {
         # ReVanced v6 moved list flags to long names and made patches flag-based.
         "list_patches": {
-            "CMD": "list-patches",
-            "DESCRIPTIONS": "--descriptions",
+            "CMD": ["list-patches"],
+            "DESCRIPTIONS": ["--descriptions"],
             # Filter flag is optional and should not be emitted unless the user explicitly overrides it.
-            "FILTER_PACKAGE_NAME": "",
-            "INDEX": "--index",
-            "OPTIONS": "--options",
-            "PACKAGES": "--packages",
-            "PATCHES": "-p",
+            "FILTER_PACKAGE_NAME": [""],
+            "INDEX": ["--index"],
+            "OPTIONS": ["--options"],
+            "PACKAGES": ["--packages"],
+            "PATCHES": ["-p"],
             # ReVanced v6 requires verification companion flags for every patches file group.
-            "PATCHES_POST": "-b",
-            "UNIVERSAL": "--universal-patches",
-            "VERSIONS": "--versions",
+            "PATCHES_POST": ["-b"],
+            "UNIVERSAL": ["--universal-patches"],
+            "VERSIONS": ["--versions"],
         },
         # Patch command still supports most legacy short flags, but v6 removes rip-lib behavior.
         "patch": {
-            "APK": POSITIONAL_ARG,
-            "CMD": "patch",
-            "DISABLED": "-d",
-            "ENABLED": "-e",
-            "EXCLUSIVE": "--exclusive",
-            "FORCE": "--force",
-            "KEYSTORE": "--keystore",
-            "KEYSTORE_ENTRY_ALIAS": KEYSTORE_ALIAS_ARG,
-            "KEYSTORE_ENTRY_PASSWORD": KEYSTORE_ENTRY_PASSWORD_ARG,
-            "KEYSTORE_PASSWORD": KEYSTORE_PASSWORD_ARG,
-            "OPTIONS": "-O",
-            "OUTPUT": "-o",
-            "PATCHES": "-p",
+            "APK": [POSITIONAL_ARG],
+            "CMD": ["patch"],
+            "DISABLED": ["-d"],
+            "ENABLED": ["-e"],
+            "EXCLUSIVE": ["--exclusive"],
+            "FORCE": ["--force"],
+            "KEYSTORE": ["--keystore"],
+            "KEYSTORE_OLD": [
+                KEYSTORE_ALIAS_ARG,
+                KEYSTORE_ENTRY_PASSWORD_ARG,
+                KEYSTORE_PASSWORD_ARG,
+            ],
+            "OPTIONS": ["-O"],
+            "OUTPUT": ["-o"],
+            "PATCHES": ["-p"],
             # ReVanced v6 requires verification companion flags for every patches file group.
-            "PATCHES_POST": "-b",
-            "PURGE": "--purge",
-            "RIP_LIB": "",
-            "STRIPLIBS": "",
+            "PATCHES_POST": ["-b"],
+            "PURGE": ["--purge"],
+            "RIP_LIB": [""],
+            "STRIPLIBS": [""],
         },
     },
     "morphe-cli": {
         # Morphe list-patches requires explicit patch bundle flags instead of positional files.
         "list_patches": {
-            "CMD": "list-patches",
-            "DESCRIPTIONS": "",
+            "CMD": ["list-patches"],
+            "DESCRIPTIONS": [""],
             # Filter flag is optional and should not be emitted unless the user explicitly overrides it.
-            "FILTER_PACKAGE_NAME": "",
-            "INDEX": "-i",
-            "OPTIONS": "-o",
-            "PACKAGES": "-p",
-            "PATCHES": "--patches",
-            "PATCHES_POST": "",
-            "UNIVERSAL": "-u",
-            "VERSIONS": "-v",
+            "FILTER_PACKAGE_NAME": [""],
+            "INDEX": ["-i"],
+            "OPTIONS": ["-o"],
+            "PACKAGES": ["-p"],
+            "PATCHES": ["--patches"],
+            "PATCHES_POST": [""],
+            "UNIVERSAL": ["-u"],
+            "VERSIONS": ["-v"],
         },
         # Morphe patch supports striplibs and keeps most names aligned with revanced-cli.
         "patch": {
-            "APK": POSITIONAL_ARG,
-            "CMD": "patch",
-            "DISABLED": "-d",
-            "ENABLED": "-e",
-            "EXCLUSIVE": "--exclusive",
-            "FORCE": "--force",
-            "KEYSTORE": "--keystore",
-            "KEYSTORE_ENTRY_ALIAS": KEYSTORE_ALIAS_ARG,
-            "KEYSTORE_ENTRY_PASSWORD": KEYSTORE_ENTRY_PASSWORD_ARG,
-            "KEYSTORE_PASSWORD": KEYSTORE_PASSWORD_ARG,
-            "OPTIONS": "-O",
-            "OUTPUT": "-o",
-            "PATCHES": "-p",
-            "PATCHES_POST": "",
-            "PURGE": "--purge",
-            "RIP_LIB": "",
-            "STRIPLIBS": "--striplibs",
+            "APK": [POSITIONAL_ARG],
+            "CMD": ["patch"],
+            "DISABLED": ["-d"],
+            "ENABLED": ["-e"],
+            "EXCLUSIVE": ["--exclusive"],
+            "FORCE": ["--force"],
+            "KEYSTORE": ["--keystore"],
+            "KEYSTORE_OLD": [
+                KEYSTORE_ALIAS_ARG,
+                KEYSTORE_ENTRY_PASSWORD_ARG,
+                KEYSTORE_PASSWORD_ARG,
+            ],
+            "OPTIONS": ["-O"],
+            "OUTPUT": ["-o"],
+            "PATCHES": ["-p"],
+            "PATCHES_POST": [""],
+            "PURGE": ["--purge"],
+            "RIP_LIB": [""],
+            "STRIPLIBS": ["--striplibs"],
         },
     },
 }
 
 
-def parse_arg_overrides(raw_overrides: str | None, allowed_keys: set[str]) -> dict[str, str]:
+def parse_arg_overrides(raw_overrides: str | None, allowed_keys: set[str]) -> dict[str, list[str]]:
     """Parse `KEY=value` override strings into a normalized dictionary."""
     # Empty values intentionally mean "no overrides", so we return quickly.
     if not raw_overrides:
         return {}
 
-    parsed_overrides: dict[str, str] = {}
+    parsed_overrides: dict[str, list[str]] = {}
 
     # We use shell tokenization so quoted values survive intact when users pass complex flags.
     for token in shlex.split(raw_overrides):
@@ -195,13 +199,14 @@ def parse_arg_overrides(raw_overrides: str | None, allowed_keys: set[str]) -> di
             logger.warning(f"Ignoring unsupported CLI override key `{normalized_key}`.")
             continue
 
-        # We keep the exact string value to avoid altering user-specified flag formatting.
-        parsed_overrides[normalized_key] = value.strip()
+        # We split the value to keep multiple flags/args for a key
+        # Example: `FORCE='--force --continue-on-error'`
+        parsed_overrides[normalized_key] = shlex.split(value.strip())
 
     return parsed_overrides
 
 
-def resolve_cli_profile(profile_name: str | None) -> dict[str, dict[str, str]]:
+def resolve_cli_profile(profile_name: str | None) -> dict[str, dict[str, list[str]]]:
     """Resolve CLI profile by name and fallback to default profile when unknown."""
     # We normalize to lowercase so env values are case-insensitive for users.
     selected_profile = (profile_name or DEFAULT_CLI_PROFILE).strip().lower()
@@ -217,12 +222,20 @@ def resolve_cli_profile(profile_name: str | None) -> dict[str, dict[str, str]]:
     return deepcopy(CLI_PROFILES[selected_profile])
 
 
+def fill_in_default_args(from_defaults: dict[str, list[str]], into_args: dict[str, list[str]]) -> dict[str, list[str]]:
+    """Fill in missing keys from defaults to ensure all expected keys are present."""
+    for key, default_value in from_defaults.items():
+        if key not in into_args:
+            into_args[key] = default_value
+    return into_args
+
+
 def merge_cli_arg_maps(
     profile_name: str | None,
     global_overrides: tuple[str | None, str | None],
     app_overrides: tuple[str | None, str | None] = (None, None),
     app_profile_name: str | None = None,
-) -> tuple[dict[str, str], dict[str, str]]:
+) -> tuple[dict[str, list[str]], dict[str, list[str]]]:
     """Resolve and merge global/app CLI argument maps."""
     # We unpack override tuples explicitly so call sites stay compact and lint-friendly.
     global_lp_overrides, global_p_overrides = global_overrides
@@ -250,37 +263,78 @@ def merge_cli_arg_maps(
     return list_patches_args, patch_args
 
 
-def append_cli_argument(args: list[str], arg_template: str, value: str | None = None) -> None:
-    """Append CLI argument from a template and optional dynamic value."""
-    # We strip whitespace so values from env files with extra spaces still behave predictably.
-    normalized_template = arg_template.strip()
+def _format_template_arg(template: str, value: str | None = None) -> list[str]:
+    """Helper to evaluate template formatting with value."""
+    if not value:
+        return [template]
 
-    # Empty template means disabled argument, so we append only the dynamic value if provided.
-    if not normalized_template:
-        if value is not None:
-            args.append(value)
+    # Consume value when POSIITONAL
+    if template == POSITIONAL_ARG:
+        return [value]
+
+    # Consume value when PLACEHOLDER
+    if "{value}" in template:
+        return [template.format(value=value)]
+
+    # Consume value when template -> '--flag='
+    if template.endswith("="):
+        return [f"{template}{value}"]
+
+    # Default behavior
+    return [template, value]
+
+
+def build_template_with_values(args: list[str], templates: list[str], values: list[str]) -> None:
+    """Extend the args with each template and use value if required.
+
+    Value is consumed for every template that is either `POSITIONAL_ARG` or
+    contains the PLACEHOLDER (--flag={value}) or
+    ends with '=' (--flag=).
+
+    If the values still remain, after extending the args with the templates,
+    the last template is used for the rest of the values.
+    """
+    current_value_index = 0
+    max_value_index = len(values) - 1 if values else -1
+    missing_value_msg = f"Missing value required for the positional arg from list of args: {templates}"
+
+    # Iterate till 2nd last template
+    for template in templates[:-1]:
+        if template == POSITIONAL_ARG or "{value}" in template or template.endswith("="):
+            if current_value_index <= max_value_index:
+                args.extend(_format_template_arg(template, values[current_value_index]))
+            else:
+                logger.warning(missing_value_msg)
+            current_value_index += 1
+        else:
+            args.append(template)
+
+    last_template = templates[-1]
+    if current_value_index > max_value_index:
+        args.append(last_template)
         return
 
-    # Positional sentinel explicitly appends only the value and omits any flag prefix.
-    if normalized_template == POSITIONAL_ARG:
-        if value is not None:
-            args.append(value)
+    # Consume rest of the values with the last template
+    while current_value_index <= max_value_index:
+        args.extend(_format_template_arg(last_template, values[current_value_index]))
+        current_value_index += 1
+
+
+def append_cli_argument(args: list[str], arg_templates: list[str], values: list[str] | None = None) -> None:
+    """Append CLI argument from a list of arg templates and an optional list of dynamic values."""
+    # We strip whitespace so values from env files with extra spaces behave predictably.
+    normalized_templates = [t.strip() for t in arg_templates if t.strip()]
+
+    # Handle completely empty templates
+    if not normalized_templates:
+        if values:
+            args.extend(values)
         return
 
-    # Static flags without value are appended as-is.
-    if value is None:
-        args.append(normalized_template)
+    # Handle completely empty values
+    if not values:
+        if normalized_templates:
+            args.extend(normalized_templates)
         return
 
-    # Template placeholders let users customize joined formatting in a controlled way.
-    if "{value}" in normalized_template:
-        args.append(normalized_template.replace("{value}", value))
-        return
-
-    # Flags ending with '=' are joined into a single token to support CLIs expecting `--flag=value`.
-    if normalized_template.endswith("="):
-        args.append(f"{normalized_template}{value}")
-        return
-
-    # Default style appends flag and value as separate tokens.
-    args.extend([normalized_template, value])
+    build_template_with_values(args, normalized_templates, values)

--- a/src/cli_args.py
+++ b/src/cli_args.py
@@ -55,13 +55,13 @@ PATCH_KEYS: Final[set[str]] = {
 # These defaults intentionally match the existing builder behavior for current stable users.
 DEFAULT_LIST_PATCHES_ARGS: Final[dict[str, list[str]]] = {
     "CMD": ["list-patches"],
-    "DESCRIPTIONS": [""],
-    "FILTER_PACKAGE_NAME": [""],
+    "DESCRIPTIONS": [],
+    "FILTER_PACKAGE_NAME": [],
     "INDEX": ["-i"],
     "OPTIONS": ["-o"],
     "PACKAGES": ["-p"],
     "PATCHES": [POSITIONAL_ARG],
-    "PATCHES_POST": [""],
+    "PATCHES_POST": [],
     "UNIVERSAL": ["-u"],
     "VERSIONS": ["-v"],
 }
@@ -83,10 +83,10 @@ DEFAULT_PATCH_ARGS: Final[dict[str, list[str]]] = {
     "OPTIONS": ["-O"],
     "OUTPUT": ["-o"],
     "PATCHES": ["-p"],
-    "PATCHES_POST": [""],
+    "PATCHES_POST": [],
     "PURGE": ["--purge"],
     "RIP_LIB": ["--rip-lib"],
-    "STRIPLIBS": [""],
+    "STRIPLIBS": [],
 }
 
 # Profile map centralizes known CLI families so users can switch format with one env variable.
@@ -101,7 +101,7 @@ CLI_PROFILES: Final[dict[str, dict[str, dict[str, list[str]]]]] = {
             "CMD": ["list-patches"],
             "DESCRIPTIONS": ["--descriptions"],
             # Filter flag is optional and should not be emitted unless the user explicitly overrides it.
-            "FILTER_PACKAGE_NAME": [""],
+            "FILTER_PACKAGE_NAME": [],
             "INDEX": ["--index"],
             "OPTIONS": ["--options"],
             "PACKAGES": ["--packages"],
@@ -131,22 +131,22 @@ CLI_PROFILES: Final[dict[str, dict[str, dict[str, list[str]]]]] = {
             # ReVanced v6 requires verification companion flags for every patches file group.
             "PATCHES_POST": ["-b"],
             "PURGE": ["--purge"],
-            "RIP_LIB": [""],
-            "STRIPLIBS": [""],
+            "RIP_LIB": [],
+            "STRIPLIBS": [],
         },
     },
     "morphe-cli": {
         # Morphe list-patches requires explicit patch bundle flags instead of positional files.
         "list_patches": {
             "CMD": ["list-patches"],
-            "DESCRIPTIONS": [""],
+            "DESCRIPTIONS": [],
             # Filter flag is optional and should not be emitted unless the user explicitly overrides it.
-            "FILTER_PACKAGE_NAME": [""],
+            "FILTER_PACKAGE_NAME": [],
             "INDEX": ["-i"],
             "OPTIONS": ["-o"],
             "PACKAGES": ["-p"],
             "PATCHES": ["--patches"],
-            "PATCHES_POST": [""],
+            "PATCHES_POST": [],
             "UNIVERSAL": ["-u"],
             "VERSIONS": ["-v"],
         },
@@ -167,13 +167,18 @@ CLI_PROFILES: Final[dict[str, dict[str, dict[str, list[str]]]]] = {
             "OPTIONS": ["-O"],
             "OUTPUT": ["-o"],
             "PATCHES": ["-p"],
-            "PATCHES_POST": [""],
+            "PATCHES_POST": [],
             "PURGE": ["--purge"],
-            "RIP_LIB": [""],
+            "RIP_LIB": [],
             "STRIPLIBS": ["--striplibs"],
         },
     },
 }
+
+
+def is_arg_enabled(arg_template: list[str]) -> bool:
+    """Check if the arg template can be used/enabled by the cli."""
+    return any(t.strip() for t in arg_template)
 
 
 def parse_arg_overrides(raw_overrides: str | None, allowed_keys: set[str]) -> dict[str, list[str]]:
@@ -224,10 +229,9 @@ def resolve_cli_profile(profile_name: str | None) -> dict[str, dict[str, list[st
 
 def fill_in_default_args(from_defaults: dict[str, list[str]], into_args: dict[str, list[str]]) -> dict[str, list[str]]:
     """Fill in missing keys from defaults to ensure all expected keys are present."""
-    for key, default_value in from_defaults.items():
-        if key not in into_args:
-            into_args[key] = default_value
-    return into_args
+    merged_args = from_defaults.copy()
+    merged_args.update(into_args)
+    return merged_args
 
 
 def merge_cli_arg_maps(
@@ -268,7 +272,7 @@ def _format_template_arg(template: str, value: str | None = None) -> list[str]:
     if not value:
         return [template]
 
-    # Consume value when POSIITONAL
+    # Consume value when POSITIONAL
     if template == POSITIONAL_ARG:
         return [value]
 

--- a/src/parser.py
+++ b/src/parser.py
@@ -8,7 +8,7 @@ from typing import Any, Self
 from loguru import logger
 
 from src.app import APP
-from src.cli_args import DEFAULT_PATCH_ARGS, append_cli_argument
+from src.cli_args import DEFAULT_PATCH_ARGS, append_cli_argument, is_arg_enabled
 from src.config import RevancedConfig
 from src.exceptions import PatchingFailedError
 from src.patches import Patches
@@ -428,12 +428,12 @@ class Parser(object):
             return
 
         # Morphe-style striplibs keeps selected architectures instead of excluding architecture-by-architecture.
-        if self._patch_args["STRIPLIBS"]:
+        if is_arg_enabled(self._patch_args["STRIPLIBS"]):
             append_cli_argument(args, self._patch_args["STRIPLIBS"], [",".join(app.archs_to_build)])
             return
 
         # Legacy rip-lib behavior is preserved for profiles that expose a compatible argument.
-        if self._patch_args["RIP_LIB"]:
+        if is_arg_enabled(self._patch_args["RIP_LIB"]):
             excluded = set(possible_archs) - set(app.archs_to_build)
             append_cli_argument(args, self._patch_args["RIP_LIB"], list(excluded))
 

--- a/src/parser.py
+++ b/src/parser.py
@@ -19,16 +19,18 @@ class Parser(object):
     """Revanced Parser."""
 
     def __init__(self: Self, patcher: Patches, config: RevancedConfig) -> None:
-        self._PATCHES: list[str] = []
+        # list[str] -> list of args for the patch
+        # str -> patch name
+        self._PATCHES: list[str | list[str]] = []
         self._EXCLUDED: list[str] = []
         self.patcher = patcher
         self.config = config
         # We initialize with default patch argument templates and update them per app profile when needed.
-        self._patch_args: dict[str, str] = dict(DEFAULT_PATCH_ARGS)
+        self._patch_args: dict[str, list[str]] = dict(DEFAULT_PATCH_ARGS)
         # These cached templates keep include/exclude logic simple and profile-aware.
-        self._options_arg = self._patch_args["OPTIONS"]
-        self._enable_arg = self._patch_args["ENABLED"]
-        self._disable_arg = self._patch_args["DISABLED"]
+        self._options_arg: list[str] = self._patch_args["OPTIONS"]
+        self._enable_arg: list[str] = self._patch_args["ENABLED"]
+        self._disable_arg: list[str] = self._patch_args["DISABLED"]
 
     def format_option(self: Self, opt: dict[str, Any]) -> str:
         """
@@ -101,12 +103,13 @@ class Parser(object):
         """
         return self._EXCLUDED
 
-    def get_all_patches(self: Self) -> list[str]:
+    def get_all_patches(self: Self) -> list[str | list[str]]:
         """The function "get_all_patches" is a getter method that returns the list of all patches.
 
         Returns
         -------
-            The method is returning a list of all patches.
+            The method is returning a list of all patches in the format
+            `["-e"], patch1, ["-e", "--some-flag"], patch2, ["-d"], patch2]`
         """
         return self._PATCHES
 
@@ -380,9 +383,10 @@ class Parser(object):
         apk_path = str(self.config.temp_folder.joinpath(app.download_file_name))
 
         # This starts the CLI invocation with jar launcher and selected patch command keyword.
-        args: list[str] = ["-jar", cli_path, self._patch_args["CMD"]]
+        args: list[str] = ["-jar", cli_path]
+        append_cli_argument(args, self._patch_args["CMD"])
         # APK argument can be positional or flagged depending on configured profile.
-        append_cli_argument(args, self._patch_args["APK"], apk_path)
+        append_cli_argument(args, self._patch_args["APK"], [apk_path])
         return args
 
     def _add_patch_bundles(self: Self, args: list[str], app: APP) -> None:
@@ -391,24 +395,24 @@ class Parser(object):
             # Multiple bundles are appended one-by-one and keep profile-specific flag formatting.
             for bundle in app.patch_bundles:
                 bundle_path = str(self.config.temp_folder.joinpath(bundle["file_name"]))
-                append_cli_argument(args, self._patch_args["PATCHES"], bundle_path)
+                append_cli_argument(args, self._patch_args["PATCHES"], [bundle_path])
                 # Some CLI families require a companion flag per patches file group (e.g., v6 `-b` bypass verification).
-                append_cli_argument(args, self._patch_args.get("PATCHES_POST", ""))
+                append_cli_argument(args, self._patch_args["PATCHES_POST"])
         else:
             # Single bundle fallback stays compatible with older resource metadata.
             bundle_path = str(self.config.temp_folder.joinpath(app.resource["patches"]["file_name"]))
-            append_cli_argument(args, self._patch_args["PATCHES"], bundle_path)
+            append_cli_argument(args, self._patch_args["PATCHES"], [bundle_path])
             # Some CLI families require a companion flag per patches file group (e.g., v6 `-b` bypass verification).
-            append_cli_argument(args, self._patch_args.get("PATCHES_POST", ""))
+            append_cli_argument(args, self._patch_args["PATCHES_POST"])
 
     def _add_output_and_keystore_args(self: Self, args: list[str], app: APP) -> None:
         """Add output file and keystore arguments."""
         # Output file path is always resolved in the temp directory used by the builder.
         output_path = str(self.config.temp_folder.joinpath(app.get_output_file_name()))
-        append_cli_argument(args, self._patch_args["OUTPUT"], output_path)
+        append_cli_argument(args, self._patch_args["OUTPUT"], [output_path])
         # Keystore path is always resolved in the temp directory used by the builder.
         keystore_path = str(self.config.temp_folder.joinpath(app.keystore_name))
-        append_cli_argument(args, self._patch_args["KEYSTORE"], keystore_path)
+        append_cli_argument(args, self._patch_args["KEYSTORE"], [keystore_path])
         # Force flag keeps current behavior unless user profile explicitly disables it.
         append_cli_argument(args, self._patch_args["FORCE"])
 
@@ -416,9 +420,7 @@ class Parser(object):
         """Add keystore-specific flags if needed."""
         if app.old_key:
             # https://github.com/ReVanced/revanced-cli/issues/272#issuecomment-1740587534
-            append_cli_argument(args, self._patch_args["KEYSTORE_ENTRY_ALIAS"])
-            append_cli_argument(args, self._patch_args["KEYSTORE_ENTRY_PASSWORD"])
-            append_cli_argument(args, self._patch_args["KEYSTORE_PASSWORD"])
+            append_cli_argument(args, self._patch_args["KEYSTORE_OLD"])
 
     def _add_architecture_args(self: Self, args: list[str], app: APP) -> None:
         """Add architecture-specific arguments."""
@@ -427,14 +429,13 @@ class Parser(object):
 
         # Morphe-style striplibs keeps selected architectures instead of excluding architecture-by-architecture.
         if self._patch_args["STRIPLIBS"]:
-            append_cli_argument(args, self._patch_args["STRIPLIBS"], ",".join(app.archs_to_build))
+            append_cli_argument(args, self._patch_args["STRIPLIBS"], [",".join(app.archs_to_build)])
             return
 
         # Legacy rip-lib behavior is preserved for profiles that expose a compatible argument.
         if self._patch_args["RIP_LIB"]:
             excluded = set(possible_archs) - set(app.archs_to_build)
-            for arch in excluded:
-                append_cli_argument(args, self._patch_args["RIP_LIB"], arch)
+            append_cli_argument(args, self._patch_args["RIP_LIB"], list(excluded))
 
     # noinspection IncorrectFormatting
     def patch_app(
@@ -460,7 +461,11 @@ class Parser(object):
         if self.config.ci_test:
             self.enable_exclusive_mode()
         if self._PATCHES:
-            args.extend(self._PATCHES)
+            for item in self._PATCHES:
+                if isinstance(item, list):
+                    args.extend(item)
+                else:
+                    args.append(item)
 
         self._add_architecture_args(args, app)
         # Purge behavior remains enabled by default and can be remapped per CLI profile.

--- a/src/patches_gen.py
+++ b/src/patches_gen.py
@@ -6,7 +6,9 @@ import subprocess
 from pathlib import Path
 from typing import Any
 
-from src.cli_args import DEFAULT_LIST_PATCHES_ARGS, append_cli_argument
+from loguru import logger
+
+from src.cli_args import DEFAULT_LIST_PATCHES_ARGS, append_cli_argument, fill_in_default_args
 
 
 def extract_name_from_section(section: str) -> str | None:
@@ -90,8 +92,13 @@ def parse_single_section(section: str) -> dict[str, Any]:
 
 def run_command_and_capture_output(patches_command: list[str]) -> str:
     """Run command and capture its output."""
-    result = subprocess.run(patches_command, capture_output=True, text=True, check=True)
-    return result.stdout
+    try:
+        result = subprocess.run(patches_command, capture_output=True, text=True, check=True)
+    except subprocess.CalledProcessError as e:
+        logger.error(e.stderr)
+        raise
+    else:
+        return result.stdout
 
 
 def parse_text_to_json(text: str) -> list[dict[Any, Any]]:
@@ -103,7 +110,7 @@ def parse_text_to_json(text: str) -> list[dict[Any, Any]]:
 def convert_command_output_to_json(
     jar_file_name: str,
     patches_file: str,
-    cli_lp_args: dict[str, str] | None = None,
+    cli_lp_args: dict[str, list[str]] | None = None,
 ) -> list[dict[Any, Any]]:
     """
     Runs the ReVanced CLI command, processes the output, and saves it as a sorted JSON file.
@@ -115,19 +122,20 @@ def convert_command_output_to_json(
     # We start from defaults and then overlay resolved per-app profile/override values.
     list_patches_args = dict(DEFAULT_LIST_PATCHES_ARGS)
     if cli_lp_args:
-        list_patches_args.update(cli_lp_args)
+        list_patches_args = fill_in_default_args(list_patches_args, cli_lp_args)
 
     # We construct the command from the configurable map to support multiple CLI syntaxes.
-    command = ["java", "-jar", jar_file_name, list_patches_args["CMD"]]
+    command = ["java", "-jar", jar_file_name]
+    append_cli_argument(command, list_patches_args["CMD"])
     # These toggles reproduce existing behavior and remain configurable for future CLI changes.
     for key in ("INDEX", "PACKAGES", "UNIVERSAL", "VERSIONS", "OPTIONS", "DESCRIPTIONS"):
-        append_cli_argument(command, list_patches_args.get(key, ""))
+        append_cli_argument(command, list_patches_args[key])
     # This optional flag slot is preserved for advanced users who embed a fixed filter in the template.
-    append_cli_argument(command, list_patches_args.get("FILTER_PACKAGE_NAME", ""))
+    append_cli_argument(command, list_patches_args["FILTER_PACKAGE_NAME"])
     # Patch bundle argument supports positional, split, or `--flag=value` formatting styles.
-    append_cli_argument(command, list_patches_args["PATCHES"], patches_file)
+    append_cli_argument(command, list_patches_args["PATCHES"], [patches_file])
     # Some CLI families require a companion flag per patches file group (e.g., v6 `-b` bypass verification).
-    append_cli_argument(command, list_patches_args.get("PATCHES_POST", ""))
+    append_cli_argument(command, list_patches_args["PATCHES_POST"])
 
     output = run_command_and_capture_output(command)
 


### PR DESCRIPTION
- Helps in using multiple flags (relevance) with the same key. Example: `FORCE='--force --continue-on-error'`
- Combined `KEYSTORE_ENTRY_*` and `KEYSTORE_PASSWORD` into single list of `KEYSTORE_OLD` key.

## Summary by Sourcery

Migrate CLI argument configuration and handling from single strings to lists of argument templates and values to support multi-flag keys and consolidated keystore options.

New Features:
- Allow CLI override values to specify multiple flags per key for commands like list-patches and patch.

Enhancements:
- Represent default and profile-specific CLI arguments as lists of string templates instead of single strings.
- Unify legacy keystore-related CLI flags into a single KEYSTORE_OLD configuration entry used when old-key signing is enabled.
- Introduce helper utilities to fill in default CLI argument maps and to build commands from template lists with optional values.
- Improve error handling and logging when invoking the CLI for patch listing by surfacing subprocess stderr output.