### PR TITLE
fix(list-patches): output parsing bug of options name being picked up as patch name

### DIFF
--- a/.github/workflows/build-artifact.yml
+++ b/.github/workflows/build-artifact.yml
@@ -85,7 +85,7 @@ jobs:
           "patchName": "Spoof client",
           "options": [
             {
-              "key": "client-id",
+              "key": "OAuth client ID",
               "value": "'${client_id}'"
             }
           ]
@@ -101,7 +101,6 @@ jobs:
             updated_json=$(echo "${json_data}" | jq ". += [${new_object}]")
           fi
           echo "${updated_json}" > "${path}"
-
 
       - name: Setup tmate session
         uses: mxschmitt/action-tmate@master

--- a/apks/options.json
+++ b/apks/options.json
@@ -3,7 +3,7 @@
     "patchName": "Spoof client",
     "options": [
       {
-        "key": "client-id",
+        "key": "OAuth client ID",
         "value": null
       }
     ]

--- a/src/patches_gen.py
+++ b/src/patches_gen.py
@@ -48,7 +48,8 @@ def parse_option_match(option_dict: dict[str, Any]) -> dict[str, Any]:
     """Parse a single option match into a dictionary."""
     title = option_dict.get("title", "").strip()
     # Use the title as the key if absent
-    if not option_dict.get("key"):
+    key = option_dict.get("key", "").strip()
+    if not key:
         key = title
 
     possible_values = []

--- a/src/patches_gen.py
+++ b/src/patches_gen.py
@@ -46,11 +46,12 @@ def extract_compatible_packages_from_section(section: str) -> list[dict[str, Any
 
 def parse_option_match(option_dict: dict[str, Any]) -> dict[str, Any]:
     """Parse a single option match into a dictionary."""
-    title = option_dict.get("title", "").strip()
+    title = option_dict.get("title", "")
+    if title:
+        title = title.strip()
     # Use the title as the key if absent
-    key = option_dict.get("key", "").strip()
-    if not key:
-        key = title
+    key = option_dict.get("key", "")
+    key = key.strip() if key else title
 
     possible_values = []
     if option_dict.get("possible_values"):

--- a/src/patches_gen.py
+++ b/src/patches_gen.py
@@ -56,7 +56,7 @@ def parse_option_match(option_dict: dict[str, Any]) -> dict[str, Any]:
     possible_values: list[str] = []
     if option_dict.get("possible_values"):
         raw_values = option_dict["possible_values"].strip().split("\n")
-        option_dict["possible_values"] = [val.strip() for val in raw_values]
+        possible_values = [val.strip() for val in raw_values]
 
     return {
         "title": title,

--- a/src/patches_gen.py
+++ b/src/patches_gen.py
@@ -53,7 +53,7 @@ def parse_option_match(option_dict: dict[str, Any]) -> dict[str, Any]:
     key = option_dict.get("key", "")
     key = key.strip() if key else title
 
-    possible_values = []
+    possible_values: list[str] = []
     if option_dict.get("possible_values"):
         raw_values = option_dict["possible_values"].strip().split("\n")
         option_dict["possible_values"] = [val.strip() for val in raw_values]

--- a/src/patches_gen.py
+++ b/src/patches_gen.py
@@ -44,40 +44,66 @@ def extract_compatible_packages_from_section(section: str) -> list[dict[str, Any
     return [extract_package_info(package_section) for package_section in package_sections[1:]]
 
 
-def parse_option_match(match: tuple[str, ...]) -> dict[str, Any]:
+def parse_option_match(option_dict: dict[str, Any]) -> dict[str, Any]:
     """Parse a single option match into a dictionary."""
+    title = option_dict.get("title", "").strip()
+    # Use the title as the key if absent
+    if not option_dict.get("key"):
+        key = title
+
+    possible_values = []
+    if option_dict.get("possible_values"):
+        raw_values = option_dict["possible_values"].strip().split("\n")
+        option_dict["possible_values"] = [val.strip() for val in raw_values]
+
     return {
-        "title": match[0].strip(),
-        "description": match[1].strip(),
-        "required": match[2].lower() == "true",
-        "key": match[3].strip(),
-        "default": match[4].strip(),
-        "possible_values": [v.strip() for v in match[5].split() if v.strip()] if match[5] else [],
-        "type": match[6].strip(),
+        "title": title,
+        "description": option_dict.get("description", "").strip(),
+        "required": option_dict.get("required", "").lower() == "true",
+        "key": key,
+        "default": option_dict.get("default", "").strip() if option_dict.get("default") else None,
+        "possible_values": possible_values,
+        "type": option_dict.get("type", "").strip(),
     }
 
 
-def extract_options_from_section(section: str) -> list[dict[str, Any]]:
-    """Extract options from a section."""
-    if "Options:" not in section:
-        return []
-
-    options_section = section.split("Options:")[1]
-    option_matches = re.findall(
-        r"Title: (.*?)\n\s*Description: (.*?)\n\s*Required: (true|false)\n\s*Key: (.*?)\n\s*Default: (.*?)\n(?:\s*Possible values:\s*(.*?))?\s*Type: (.*?)\n",  # noqa: E501
-        options_section,
-        re.DOTALL,
+def extract_options_from_section(options_section: str) -> list[dict[str, Any]]:
+    """Extract options from an options section."""
+    regex = re.compile(
+        r"(?:Title|Name):\s*(?P<title>[^\n]+)\n"
+        r"\s*Description:\s*(?P<description>[^\n]+)\n"
+        r"\s*Required:\s*(?P<required>true|false)\n"
+        r"(?:\s*Key:\s*(?P<key>[^\n]+)\n)?"
+        r"(?:\s*Default:\s*(?P<default>[^\n]+)\n)?"
+        r"(?:\s*Possible values:\n(?P<possible_values>[\s\S]*?))?"
+        r"\s*Type:\s*(?P<type>[^\n]+)",
+        re.VERBOSE,
     )
-    return [parse_option_match(match) for match in option_matches]
+    return [parse_option_match(match.groupdict()) for match in regex.finditer(options_section)]
+
+
+def split_section(section: str) -> tuple[str, str]:
+    """Split a section into patch and options parts."""
+    patch_section = section
+    options_section = ""
+
+    options_section_regex = re.compile(r"^Options:(?:\n(?!\w).*)*", re.MULTILINE)
+    match = options_section_regex.search(section)
+    if match:
+        patch_section = (section[: match.start()] + section[match.end() :]).rstrip() + "\n\n"
+        options_section = match.group(0)
+
+    return patch_section, options_section
 
 
 def parse_single_section(section: str) -> dict[str, Any]:
     """Parse a single section into a dictionary."""
-    name = extract_name_from_section(section)
-    description = extract_description_from_section(section)
-    enabled = extract_enabled_state_from_section(section)
-    compatible_packages = extract_compatible_packages_from_section(section)
-    options = extract_options_from_section(section)
+    patch_section, options_section = split_section(section)
+    name = extract_name_from_section(patch_section)
+    description = extract_description_from_section(patch_section)
+    enabled = extract_enabled_state_from_section(patch_section)
+    compatible_packages = extract_compatible_packages_from_section(patch_section)
+    options = extract_options_from_section(options_section)
 
     return {
         "name": name,
@@ -96,7 +122,7 @@ def run_command_and_capture_output(patches_command: list[str]) -> str:
 
 def parse_text_to_json(text: str) -> list[dict[Any, Any]]:
     """Parse text output into JSON format."""
-    sections = re.split(r"(?=Name:)", text)
+    sections = re.split(r"(?=^Name:)", text, flags=re.MULTILINE)
     return [parse_single_section(section) for section in sections]
 
 

--- a/src/patches_gen.py
+++ b/src/patches_gen.py
@@ -73,7 +73,7 @@ def extract_options_from_section(options_section: str) -> list[dict[str, Any]]:
     """Extract options from an options section."""
     regex = re.compile(
         r"(?:Title|Name):\s*(?P<title>[^\n]+)\n"
-        r"\s*Description:\s*(?P<description>[^\n]+)\n"
+        r"\s*Description:\s*(?P<description>[\s\S]*?)\n"  ## allows multi-line descriptions
         r"\s*Required:\s*(?P<required>true|false)\n"
         r"(?:\s*Key:\s*(?P<key>[^\n]+)\n)?"
         r"(?:\s*Default:\s*(?P<default>[^\n]+)\n)?"


### PR DESCRIPTION
- Earlier, patch used Name and options used Title. Likely, after an
update revanced has shifted to use Name for both, which was the cause.
- Also, looks like they also moved onto options Name as the Key instead
of the explicitly defining one.

---

## Summary by Sourcery

Fix parsing of patch list sections so option metadata is extracted from a dedicated options block rather than being misinterpreted as patch names, and adjust related CI workflow configuration accordingly.

Bug Fixes:
- Correct option parsing to handle titles/names, optional keys, defaults, and possible values without misclassifying them as patch names.
- Ensure sections are split on line-anchored patch names and options blocks so patch metadata and options are parsed independently.

CI:
- Update build artifact workflow to reference the correct patch option key for the spoof client configuration.