### PR TITLE
refactor: add support to strip apps from `ARCHS_TO_BUILD`

### DIFF
--- a/README.md
+++ b/README.md
@@ -142,11 +142,11 @@ You can use any of the following methods to build.
 
 | Env Name                                                      |                                             Description                                              | Default                        |
 |:--------------------------------------------------------------|:----------------------------------------------------------------------------------------------------:|:-------------------------------|
-| [**APP_NAME**_CLI_DL](#global-resources)                      |                     DL for CLI to be used for patching **APP_NAME**.                 | GLOBAL_CLI_DL                  |
+| [**APP_NAME**_CLI_DL](#global-resources)                      |                          DL for CLI to be used for patching **APP_NAME**.                            | GLOBAL_CLI_DL                  |
 | [**APP_NAME**_PATCHES_DL](#global-resources)                  | DL for Patches to be used for patching **APP_NAME**. Supports multiple bundles via comma separation. | GLOBAL_PATCHES_DL              |
 | [**APP_NAME**_SPACE_FORMATTED_PATCHES](#global-resources)     |                         Whether patches are space formatted.   **APP_NAME**.                         | GLOBAL_SPACE_FORMATTED_PATCHES |
 | [**APP_NAME**_KEYSTORE_FILE_NAME](#global-keystore-file-name) |                            Key file to be used for signing **APP_NAME**.                             | GLOBAL_KEYSTORE_FILE_NAME      |
-| [**APP_NAME**_OLD_KEY](#global-keystore-file-name)            |     Whether key used was generated with cli > v4(new) <br/><br/>**APP_NAME**.      <br/>   <br/>     | GLOBAL_OLK_KEY                 |
+| [**APP_NAME**_OLD_KEY](#global-keystore-file-name)            |     Whether key used was generated with cli > v4(new) <br/><br/>**APP_NAME**.      <br/>   <br/>     | GLOBAL_OLD_KEY                 |
 | [**APP_NAME**_ARCHS_TO_BUILD](#global-archs-to-build)         |                              Arch to keep in the patched **APP_NAME**.                               | GLOBAL_ARCHS_TO_BUILD          |
 | [**APP_NAME**_CLI_ARGSF](#cli-arg-compatibility)              |                                CLI argument profile for **APP_NAME**.                                | GLOBAL_CLI_ARGSF               |
 | [**APP_NAME**_CLI_LPARGS](#cli-arg-compatibility)             |                           Override map for **APP_NAME** list-patches args.                           | GLOBAL_CLI_LPARGS              |

--- a/README.md
+++ b/README.md
@@ -114,7 +114,7 @@ You can use any of the following methods to build.
 | [EXISTING_DOWNLOADED_APKS ](#existing-downloaded-apks)   |              Already downloaded clean apks              | []                                                                                                                    |
 | [PERSONAL_ACCESS_TOKEN](#personal-access-token)          |             GitHub/GitLab Token to be used              | None                                                                                                                  |
 | DRY_RUN                                                  |                      Do a dry run                       | False                                                                                                                 |
-| [~~GLOBAL_CLI_DL*~~](#global-resources)                  | DL for CLI to be used for patching apps.(Disabled Temp) | [Revanced CLI](https://github.com/revanced/revanced-cli)                                                              |
+| [GLOBAL_CLI_DL*](#global-resources)                      |          DL for CLI to be used for patching apps.       | [Revanced CLI](https://github.com/revanced/revanced-cli)                                                                                     |
 | [GLOBAL_PATCHES_DL*](#global-resources)                  |      DL for Patches to be used for patching apps.       | [ReVanced API patches bundle](https://api.revanced.app/v5/patches.rvp)                                                |
 | [GLOBAL_SPACE_FORMATTED_PATCHES*](#global-resources)     |          Whether patches are space formatted.           | True                                                                                                                  |
 | [GLOBAL_KEYSTORE_FILE_NAME*](#global-keystore-file-name) |          Key file to be used for signing apps           | [Builder's own key](https://github.com/nikhilbadyal/docker-py-revanced/blob/main/apks/revanced.keystore)              |
@@ -142,7 +142,7 @@ You can use any of the following methods to build.
 
 | Env Name                                                      |                                             Description                                              | Default                        |
 |:--------------------------------------------------------------|:----------------------------------------------------------------------------------------------------:|:-------------------------------|
-| [~~**APP_NAME**_CLI_DL~~](#global-resources)                  |                   DL for CLI to be used for patching **APP_NAME**.(Disabled Temp)                    | GLOBAL_CLI_DL                  |
+| [**APP_NAME**_CLI_DL](#global-resources)                      |                     DL for CLI to be used for patching **APP_NAME**.                 | GLOBAL_CLI_DL                  |
 | [**APP_NAME**_PATCHES_DL](#global-resources)                  | DL for Patches to be used for patching **APP_NAME**. Supports multiple bundles via comma separation. | GLOBAL_PATCHES_DL              |
 | [**APP_NAME**_SPACE_FORMATTED_PATCHES](#global-resources)     |                         Whether patches are space formatted.   **APP_NAME**.                         | GLOBAL_SPACE_FORMATTED_PATCHES |
 | [**APP_NAME**_KEYSTORE_FILE_NAME](#global-keystore-file-name) |                            Key file to be used for signing **APP_NAME**.                             | GLOBAL_KEYSTORE_FILE_NAME      |

--- a/src/config.py
+++ b/src/config.py
@@ -17,7 +17,6 @@ class RevancedConfig(object):
         self.temp_folder_name = resource_folder
         self.temp_folder = Path(self.temp_folder_name)
         self.ci_test = env.bool("CI_TEST", False)
-        self.rip_libs_apps: list[str] = []
         self.existing_downloaded_apks = env.list("EXISTING_DOWNLOADED_APKS", [])
         self.personal_access_token = env.str("PERSONAL_ACCESS_TOKEN", None)
         self.dry_run = env.bool("DRY_RUN", False)

--- a/src/config.py
+++ b/src/config.py
@@ -6,7 +6,7 @@ from typing import Self
 from environs import Env
 
 from src.cli_args import DEFAULT_CLI_PROFILE
-from src.utils import default_build, default_cli, default_patches, resource_folder
+from src.utils import default_build, default_cli, default_patches, possible_archs, resource_folder
 
 
 class RevancedConfig(object):
@@ -25,7 +25,7 @@ class RevancedConfig(object):
         self.global_patches_dl = env.str("GLOBAL_PATCHES_DL", default_patches)
         self.global_keystore_name = env.str("GLOBAL_KEYSTORE_FILE_NAME", "revanced.keystore")
         self.global_options_file = env.str("GLOBAL_OPTIONS_FILE", "options.json")
-        self.global_archs_to_build = env.list("GLOBAL_ARCHS_TO_BUILD", [])
+        self.global_archs_to_build = env.list("GLOBAL_ARCHS_TO_BUILD", possible_archs)
         self.extra_download_files: list[str] = env.list("EXTRA_FILES", [])
         self.apk_editor = "apkeditor-output.jar"
         self.extra_download_files.append("https://github.com/REAndroid/APKEditor@apkeditor.jar")

--- a/src/parser.py
+++ b/src/parser.py
@@ -425,6 +425,10 @@ class Parser(object):
         if app.app_name not in self.config.rip_libs_apps:
             return
 
+        excluded = set(possible_archs) - set(app.archs_to_build)
+        if len(excluded) == 0:
+            return
+
         # Morphe-style striplibs keeps selected architectures instead of excluding architecture-by-architecture.
         if self._patch_args["STRIPLIBS"]:
             append_cli_argument(args, self._patch_args["STRIPLIBS"], ",".join(app.archs_to_build))
@@ -432,7 +436,6 @@ class Parser(object):
 
         # Legacy rip-lib behavior is preserved for profiles that expose a compatible argument.
         if self._patch_args["RIP_LIB"]:
-            excluded = set(possible_archs) - set(app.archs_to_build)
             for arch in excluded:
                 append_cli_argument(args, self._patch_args["RIP_LIB"], arch)
 

--- a/src/parser.py
+++ b/src/parser.py
@@ -421,10 +421,11 @@ class Parser(object):
             append_cli_argument(args, self._patch_args["KEYSTORE_PASSWORD"])
 
     def _add_architecture_args(self: Self, args: list[str], app: APP) -> None:
-        """Add architecture-specific arguments."""
-        if app.app_name not in self.config.rip_libs_apps:
-            return
+        """
+        Add architecture-specific arguments.
 
+        Note: Strip only, if the app config has set the `ARCHS_TO_BUILD` != set(possible_archs)
+        """
         excluded = set(possible_archs) - set(app.archs_to_build)
         if len(excluded) == 0:
             return

--- a/src/utils.py
+++ b/src/utils.py
@@ -29,7 +29,7 @@ default_build = [
     "youtube",
     "youtube_music",
 ]
-possible_archs = ["armeabi-v7a", "x86", "x86_64", "arm64-v8a"]
+possible_archs = ["arm64-v8a", "armeabi-v7a", "x86_64", "x86"]
 request_header = {
     "User-Agent": "Mozilla/5.0 (Windows NT 10.0; Win64; x64) "
     "AppleWebKit/537.36 (HTML, like Gecko)"


### PR DESCRIPTION
## Summary by Sourcery

Refine architecture stripping behavior based on configured target architectures and update related defaults and documentation.

Enhancements:
- Change architecture argument generation to only strip libraries when an app’s configured architectures differ from the full supported set.
- Set the global default architectures-to-build to the full list of supported architectures and standardize their ordering.
- Remove unused configuration for explicitly listing apps that should have libraries stripped.

Documentation:
- Re-enable and correct documentation for per-app and global CLI download environment variables and fix the documented default for per-app old key configuration.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated environment variable configuration tables with improved formatting, clarity, and corrections.
  * Fixed typo in configuration variable references.

* **Improvements**
  * Enhanced architecture configuration system with streamlined default value handling.
  * Optimized architecture argument processing by computing excluded architectures up-front for better performance.
  * Adjusted supported architecture list ordering.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/nikhilbadyal/docker-py-revanced/pull/732)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->