### PR TITLE
Fix repeated dots in slugified filenames

### DIFF
--- a/src/utils.py
+++ b/src/utils.py
@@ -193,8 +193,9 @@ def slugify(string: str) -> str:
     # Replace spaces with dashes
     modified_string = re.sub(r"\s+", ".", modified_string)
 
-    # Remove consecutive dashes
+    # Collapse separator runs
     modified_string = re.sub(r"-+", ".", modified_string)
+    modified_string = re.sub(r"\.+", ".", modified_string)
 
     # Remove leading and trailing dashes
     return modified_string.strip(".")

--- a/tests/test_obtainium_export.py
+++ b/tests/test_obtainium_export.py
@@ -59,6 +59,13 @@ class ObtainiumExportTests(TestCase):
         self.assertIn("PatchVersionv1.0.0.v3.0.0", second_name)
         self.assertNotEqual(first_name, second_name)
 
+    def test_output_file_name_collapses_repeated_dots(self: Self) -> None:
+        """Generated release asset names should match GitHub's uploaded asset names."""
+        app = _app_with_patch_bundles("v2.0.0")
+        app.app_version = "50.1.1..5001014"
+
+        self.assertIn("Version50.1.1.5001014", app.get_output_file_name())
+
     def test_generate_obtainium_export_encodes_url_and_slugifies_html_name(self: Self) -> None:
         """Generated HTML should be safe to serve and should link to the exact encoded release asset."""
         with TemporaryDirectory() as temp_dir, chdir(temp_dir):


### PR DESCRIPTION
## Issue

  I encountered this while patching Windy with Morphe CLI and rushiranpise's Morphe patches:

  - App: Windy
  - APK source: APKMirror
  - Patch source: https://github.com/rushiranpise/morphe-patches
  - CLI: https://github.com/MorpheApp/morphe-cli

  APKMirror exposed the Windy version in a form that became `50.1.1..5001014` after `slugify()`. That
  filename was written into `updates.json` and the Obtainium HTML export.

  The release upload then stored the GitHub asset as `50.1.1.5001014` with a single dot, so the generated
  Obtainium download link pointed to a missing asset.

  Example mismatch:

  ```text
  Generated metadata:
  ReWindy-Version50.1.1..5001014-...

  Uploaded release asset:
  ReWindy-Version50.1.1.5001014-...
  ```
  ## Fix

  Collapse repeated dots in slugify() so generated metadata filenames match the uploaded GitHub release
  asset names.

  Also added a small regression test for output filename generation.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved filename formatting by collapsing repeated dots in generated version strings.
  * Prevented extra separators from appearing in release asset filenames.

* **Tests**
  * Added regression coverage for version strings containing consecutive dots.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->