### PR TITLE
fix: stop passing unsupported --purge to Morphe CLI

### DIFF
--- a/src/cli_args.py
+++ b/src/cli_args.py
@@ -139,7 +139,7 @@ CLI_PROFILES: Final[dict[str, dict[str, dict[str, str]]]] = {
             "OUTPUT": "-o",
             "PATCHES": "-p",
             "PATCHES_POST": "",
-            "PURGE": "--purge",
+            "PURGE": "",
             "RIP_LIB": "",
             "STRIPLIBS": "--striplibs",
             # Morphe otherwise uses `/app/morphe-temporary-files`, which parallel apps can delete mid-patch.

--- a/tests/test_cli_args.py
+++ b/tests/test_cli_args.py
@@ -17,6 +17,7 @@ class CliArgProfileTests(TestCase):
         list_patch_args, patch_args = merge_cli_arg_maps("morphe-cli", ("", ""))
 
         self.assertEqual("--continue-on-error", patch_args["CONTINUE_ON_ERROR"])
+        self.assertEqual("", patch_args["PURGE"])
         self.assertEqual("-t", list_patch_args["TEMPORARY_FILES_PATH"])
         self.assertEqual("-t", patch_args["TEMPORARY_FILES_PATH"])
 


### PR DESCRIPTION
  Morphe CLI v1.10+ purges temporary files by default and replaced `--purge` with the opt-out flag
  `--disable-purge`.

https://github.com/MorpheApp/morphe-desktop/pull/192

  Remove the unsupported `--purge` argument from the Morphe CLI profile.

  ## Result

  Prevents Morphe builds from failing with:

  `Unknown option: '--purge'`

  Adds a regression assertion.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated the Morphe CLI profile so patch operations no longer automatically include the `--purge` option.
  * Preserved the default `--continue-on-error` behavior for the profile.

* **Tests**
  * Added coverage to verify the corrected patch argument behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->