### PR TITLE
build!: update to jdk-21

### DIFF
--- a/Dockerfile-base
+++ b/Dockerfile-base
@@ -7,31 +7,37 @@ FROM python:${PYTHON_VERSION} AS python
 # Set ARGs and ENVs
 ARG APP_HOME=/app
 
-ENV PYTHONUNBUFFERED 1
-ENV PYTHONDONTWRITEBYTECODE 1
+ENV PYTHONUNBUFFERED=1
+ENV PYTHONDONTWRITEBYTECODE=1
 WORKDIR ${APP_HOME}
 ENV LANG='en_US.UTF-8' LANGUAGE='en_US:en' LC_ALL='en_US.UTF-8'
-ARG ZULU_REPO_VER=1.0.0-3
+ARG JDK_VERSION=21
 
 
 # Update package lists and install required packages
 RUN apt-get -qq update && \
-    apt-get -qq -y --no-install-recommends install gnupg software-properties-common locales curl tzdata git && \
+    apt-get -qq -y --no-install-recommends install gnupg ca-certificates locales curl tzdata git && \
     echo "en_US.UTF-8 UTF-8" >> /etc/locale.gen && \
     locale-gen en_US.UTF-8 && \
-    apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys 0xB1998361219BD9C9 && \
-    curl -sLO https://cdn.azul.com/zulu/bin/zulu-repo_${ZULU_REPO_VER}_all.deb && dpkg -i zulu-repo_${ZULU_REPO_VER}_all.deb && \
+    curl -fsSL https://repos.azul.com/azul-repo.key \
+        | gpg --dearmor -o /usr/share/keyrings/azul.gpg && \
+    chmod 644 /usr/share/keyrings/azul.gpg && \
+    echo "deb [signed-by=/usr/share/keyrings/azul.gpg] https://repos.azul.com/zulu/deb stable main" \
+        > /etc/apt/sources.list.d/zulu.list && \
     apt-get -qq update && \
     apt-get -qq -y upgrade && \
-    mkdir -p /usr/share/man/man1 && \
-    echo "Package: zulu17-*\nPin: version 17.0.4-*\nPin-Priority: 1001" > /etc/apt/preferences && \
-    apt-get -qq -y --no-install-recommends install zulu17-jdk=17.0.4-* && \
-    apt-get -qq -y purge gnupg software-properties-common curl && \
+    apt-get -qq -y --no-install-recommends install zulu${JDK_VERSION}-jdk && \
+    apt-get -qq -y purge gnupg curl && \
     apt-get -y autoremove && \
-    rm -rf /var/lib/apt/lists/* zulu-repo_${ZULU_REPO_VER}_all.deb
+    rm -rf /var/lib/apt/lists/*
 
 # Set Java home environment variable
-ENV JAVA_HOME=/usr/lib/jvm/zulu17-ca-amd64
+RUN JAVA_BIN="$(readlink -f "$(command -v java)")" && \
+    JAVA_HOME="${JAVA_BIN%/bin/java}" && \
+    ln -s "$JAVA_HOME" /opt/java-home
+
+ENV JAVA_HOME=/opt/java-home
+ENV PATH="${JAVA_HOME}/bin:${PATH}"
 
 # Ensure curl and jq are available for the next step
 RUN apt-get update && \

--- a/README.md
+++ b/README.md
@@ -85,7 +85,7 @@ You can use any of the following methods to build.
 
 - 🫠Without Docker
 
-    1. Install Java >= 17
+    1. Install Java >= 21
     2. Install Python >= 3.11
     3. Create virtual environment
        ```

--- a/src/utils.py
+++ b/src/utils.py
@@ -33,7 +33,7 @@ default_build = [
     "youtube_music",
 ]
 possible_archs = ["armeabi-v7a", "x86", "x86_64", "arm64-v8a"]
-minimum_java_major_version = 17
+minimum_java_major_version = 21
 # Use a syntactically valid desktop Chrome identity because APKMirror and artifact hosts may reject impossible browsers.
 request_header = {
     "User-Agent": "Mozilla/5.0 (Windows NT 10.0; Win64; x64) "
@@ -216,19 +216,14 @@ def _check_version(output: str) -> None:
 
 
 def check_java() -> None:
-    """The function `check_java` checks if Java version 17 or higher is installed.
-
-    Returns
-    -------
-        The function `check_java` does not return any value.
-    """
+    """Check that the installed Java version meets the minimum requirement."""
     try:
         jd = subprocess.check_output(["java", "-version"], stderr=subprocess.STDOUT).decode("utf-8")
         jd = jd[1:-1]
         _check_version(jd)
         logger.debug("Cool!! Java is available")
     except subprocess.CalledProcessError:
-        logger.error("Java>= 17 must be installed")
+        logger.error(f"Java >= {minimum_java_major_version} must be installed")
         sys.exit(-1)
 
 

--- a/tests/test_runtime_guards.py
+++ b/tests/test_runtime_guards.py
@@ -56,13 +56,13 @@ class RuntimeGuardTests(TestCase):
     """Verify runtime checks and logs fail safely."""
 
     def test_java_version_parser_accepts_current_major_versions(self: Self) -> None:
-        """Java 17+ should pass regardless of vendor wording or release year."""
+        """Java 21+ should pass regardless of vendor wording or release year."""
         _check_version('openjdk version "26.0.1" 2026-04-21\nOpenJDK Runtime Environment')
 
     def test_java_version_parser_rejects_unsupported_major_versions(self: Self) -> None:
-        """Java versions below 17 cannot run the current patching toolchain."""
+        """Java versions below 21 cannot run the current patching toolchain."""
         with self.assertRaises(subprocess.CalledProcessError):
-            _check_version('openjdk version "11.0.24" 2024-07-16\nOpenJDK Runtime Environment')
+            _check_version('openjdk version "17.0.24" 2024-07-16\nOpenJDK Runtime Environment')
 
     def test_apkeep_command_log_redacts_credentials(self: Self) -> None:
         """APKEEP credentials should be used for execution but never written to debug logs."""


### PR DESCRIPTION
- Bump due to Morphe-Desktop requiring jdk-21 and onwards
- Refactor the legacy env var value

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for selecting the Java Development Kit version during container builds.
  * Updated runtime requirements to support Java 21 and newer.
  * Improved automatic Java environment configuration.

* **Documentation**
  * Updated build instructions to require Java 21 or later.

* **Tests**
  * Updated runtime checks to validate Java 21+ compatibility and reject older versions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->