### PR TITLE
Thread the actual GitHub release tag through to Obtainium export

### DIFF
--- a/.github/workflows/auto-release.yml
+++ b/.github/workflows/auto-release.yml
@@ -3,10 +3,6 @@ env:
   DOCKER_BUILDKIT: 1
   COMPOSE_DOCKER_CLI_BUILD: 1
   HAVE_TELEGRAM_API_ID: ${{ secrets.TELEGRAM_API_ID != '' }}
-  # Defaults used only for schedule-triggered runs, where `inputs` is unset entirely (manual
-  # workflow_dispatch runs use each input's own `default:` instead). Set true/false directly.
-  SCHEDULED_TELEGRAM_NO_ROOT_UPLOAD: true
-  SCHEDULED_DELETE_OLDER_RELEASES: true
 on:
   workflow_dispatch:
     inputs:
@@ -29,6 +25,14 @@ jobs:
     concurrency:
       group: ${{ github.head_ref || github.run_id }}
       cancel-in-progress: true
+    env:
+      # Defaults used only for schedule-triggered runs of build-release below, where `inputs` is
+      # unset entirely (manual workflow_dispatch runs use each input's own `default:` instead).
+      # Set true/false directly. Exposed via outputs since `env` isn't an allowed context inside
+      # a reusable workflow call's `with:` mapping (only github, needs, strategy, matrix, inputs,
+      # vars are).
+      SCHEDULED_TELEGRAM_NO_ROOT_UPLOAD: true
+      SCHEDULED_DELETE_OLDER_RELEASES: true
     steps:
       - name: Checkout
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
@@ -55,8 +59,16 @@ jobs:
         run: |
           should_build=$(python check_resource_updates.py)
           echo "SHOULD_BUILD=$should_build" >> $GITHUB_OUTPUT
+
+      - name: Expose scheduled-run defaults
+        id: scheduled_defaults
+        run: |
+          echo "TELEGRAM_NO_ROOT_UPLOAD=$SCHEDULED_TELEGRAM_NO_ROOT_UPLOAD" >> "$GITHUB_OUTPUT"
+          echo "DELETE_OLDER_RELEASES=$SCHEDULED_DELETE_OLDER_RELEASES" >> "$GITHUB_OUTPUT"
     outputs:
       SHOULD_BUILD: ${{ steps.should_build.outputs.SHOULD_BUILD }}
+      SCHEDULED_TELEGRAM_NO_ROOT_UPLOAD: ${{ steps.scheduled_defaults.outputs.TELEGRAM_NO_ROOT_UPLOAD }}
+      SCHEDULED_DELETE_OLDER_RELEASES: ${{ steps.scheduled_defaults.outputs.DELETE_OLDER_RELEASES }}
 
   build-release:
     permissions: write-all
@@ -71,11 +83,11 @@ jobs:
       PREFERRED_PATCH_APPS: ${{ needs.release-check.outputs.SHOULD_BUILD }}
       TELEGRAM_NO_ROOT_UPLOAD: >-
         ${{
-          (github.event_name == 'schedule' && fromJSON(env.SCHEDULED_TELEGRAM_NO_ROOT_UPLOAD))
+          (github.event_name == 'schedule' && fromJSON(needs.release-check.outputs.SCHEDULED_TELEGRAM_NO_ROOT_UPLOAD))
           || (github.event_name != 'schedule' && inputs.TELEGRAM_NO_ROOT_UPLOAD)
         }}
       DELETE_OLDER_RELEASES: >-
         ${{
-          (github.event_name == 'schedule' && fromJSON(env.SCHEDULED_DELETE_OLDER_RELEASES))
+          (github.event_name == 'schedule' && fromJSON(needs.release-check.outputs.SCHEDULED_DELETE_OLDER_RELEASES))
           || (github.event_name != 'schedule' && inputs.DELETE_OLDER_RELEASES)
         }}

--- a/.github/workflows/auto-release.yml
+++ b/.github/workflows/auto-release.yml
@@ -3,11 +3,20 @@ env:
   DOCKER_BUILDKIT: 1
   COMPOSE_DOCKER_CLI_BUILD: 1
   HAVE_TELEGRAM_API_ID: ${{ secrets.TELEGRAM_API_ID != '' }}
+  # Defaults used only for schedule-triggered runs, where `inputs` is unset entirely (manual
+  # workflow_dispatch runs use each input's own `default:` instead). Set true/false directly.
+  SCHEDULED_TELEGRAM_NO_ROOT_UPLOAD: true
+  SCHEDULED_DELETE_OLDER_RELEASES: true
 on:
   workflow_dispatch:
     inputs:
       TELEGRAM_NO_ROOT_UPLOAD:
         description: "Upload Non Rooted APKs to Telegram"
+        required: false
+        type: boolean
+        default: true
+      DELETE_OLDER_RELEASES:
+        description: "Delete older Build-* releases before uploading. This workflow does partial builds (only apps with updates), so disable to avoid dropping releases for apps not included in a given run."
         required: false
         type: boolean
         default: true
@@ -59,5 +68,14 @@ jobs:
       group: Auto-Release-${{ github.head_ref || github.run_id }}
       cancel-in-progress: true
     with:
-      TELEGRAM_NO_ROOT_UPLOAD: true
       PREFERRED_PATCH_APPS: ${{ needs.release-check.outputs.SHOULD_BUILD }}
+      TELEGRAM_NO_ROOT_UPLOAD: >-
+        ${{
+          (github.event_name == 'schedule' && fromJSON(env.SCHEDULED_TELEGRAM_NO_ROOT_UPLOAD))
+          || (github.event_name != 'schedule' && inputs.TELEGRAM_NO_ROOT_UPLOAD)
+        }}
+      DELETE_OLDER_RELEASES: >-
+        ${{
+          (github.event_name == 'schedule' && fromJSON(env.SCHEDULED_DELETE_OLDER_RELEASES))
+          || (github.event_name != 'schedule' && inputs.DELETE_OLDER_RELEASES)
+        }}

--- a/.github/workflows/build-apk.yml
+++ b/.github/workflows/build-apk.yml
@@ -41,6 +41,11 @@ on:
         description: "Apps to be patched. Overrides any env set"
         required: false
         type: string
+      DELETE_OLDER_RELEASES:
+        description: "Delete older Build-* releases before uploading. Disable for partial builds so releases for apps not included in this run aren't lost."
+        required: false
+        type: boolean
+        default: true
   workflow_dispatch:
     inputs:
       GITHUB_UPLOAD:
@@ -78,17 +83,34 @@ on:
         description: "Apps to be patched. Overrides any env set"
         required: false
         type: string
+      DELETE_OLDER_RELEASES:
+        description: "Delete older Build-* releases before uploading. Disable for partial builds so releases for apps not included in this run aren't lost."
+        required: false
+        type: boolean
+        default: true
 
 concurrency:
   group: ${{ github.head_ref || github.run_id }}
   cancel-in-progress: true
 jobs:
+  compute-tag:
+    runs-on: ubuntu-latest
+    outputs:
+      RELEASE_TAG: ${{ steps.get-date.outputs.tag }}
+    steps:
+      - name: Get Date
+        id: get-date
+        run: |
+          echo "tag=Build-$(TZ='Asia/Kolkata' date +"%Y.%m.%d-%H.%M.%S")" >> $GITHUB_OUTPUT
+
   build-apk:
+    needs: compute-tag
     uses: ./.github/workflows/build-artifact.yml
     with:
       COMMIT_CHANGELOG: ${{ inputs.COMMIT_CHANGELOG }}
       DEBUG_ENABLED: ${{ inputs.DEBUG_ENABLED }}
       PREFERRED_PATCH_APPS: ${{ inputs.PREFERRED_PATCH_APPS }}
+      RELEASE_TAG: ${{ needs.compute-tag.outputs.RELEASE_TAG }}
     secrets:
       ENVS: ${{ secrets.ENVS }}
       DOCKER_PY_REVANCED_SECRETS: ${{ secrets.DOCKER_PY_REVANCED_SECRETS }}
@@ -98,7 +120,7 @@ jobs:
     name: GitHub Upload
     runs-on: ubuntu-latest
     timeout-minutes: 30
-    needs: build-apk
+    needs: [ compute-tag, build-apk ]
     if: inputs.GITHUB_UPLOAD
 
     steps:
@@ -106,12 +128,9 @@ jobs:
         uses: actions/download-artifact@main
         with:
           name: Built-APKs
-      - name: Get Date
-        id: get-date
-        run: |
-          echo "date=$(TZ='Asia/Kolkata' date +"%Y.%m.%d-%H.%M.%S")" >> $GITHUB_OUTPUT
 
       - name: Delete Older Releases
+        if: inputs.DELETE_OLDER_RELEASES
         uses: nikhilbadyal/ghaction-rm-releases@0a58d2ce5d2bf162d18e6c01712cc0e53b2bab45 # v0.8.0
         with:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -122,7 +141,7 @@ jobs:
         with:
           artifacts: "apks/*-output.apk,updates.json,changelog.json,changelog.md"
           token: ${{ secrets.GITHUB_TOKEN }}
-          tag: Build-${{ steps.get-date.outputs.date }}
+          tag: ${{ needs.compute-tag.outputs.RELEASE_TAG }}
           artifactErrorsFailBuild: true
 
       - name: Sleep for 10 seconds

--- a/.github/workflows/build-apk.yml
+++ b/.github/workflows/build-apk.yml
@@ -95,6 +95,7 @@ concurrency:
 jobs:
   compute-tag:
     runs-on: ubuntu-latest
+    permissions: {}
     outputs:
       RELEASE_TAG: ${{ steps.get-date.outputs.tag }}
     steps:

--- a/.github/workflows/build-artifact.yml
+++ b/.github/workflows/build-artifact.yml
@@ -53,11 +53,7 @@ jobs:
           echo "${{ secrets.ENVS }}" >> .env
           echo "GITHUB_REPOSITORY=${{ github.repository }}" >> .env
           # Only fill in the tag when the caller didn't already pin a non-empty custom
-          # OBTAINIUM_GITHUB_TAG via secrets.ENVS. Dotenv semantics: last occurrence of the key
-          # wins, and its value may be quoted/padded with whitespace, so a plain key-presence
-          # grep would wrongly treat `OBTAINIUM_GITHUB_TAG=` (empty) as already pinned. The
-          # trailing `|| true` keeps a no-match grep (the common case) from tripping bash -eo
-          # pipefail, under which run: steps execute by default.
+          # OBTAINIUM_GITHUB_TAG via secrets.ENVS
           existing_tag=$(grep '^OBTAINIUM_GITHUB_TAG=' .env | tail -n1 | cut -d'=' -f2- | sed -e 's/^[[:space:]]*//' -e 's/[[:space:]]*$//' -e "s/^['\"]//" -e "s/['\"]$//" || true)
           if [ -n "${RELEASE_TAG}" ] && [ -z "${existing_tag}" ]; then
             echo "OBTAINIUM_GITHUB_TAG=${RELEASE_TAG}" >> .env

--- a/.github/workflows/build-artifact.yml
+++ b/.github/workflows/build-artifact.yml
@@ -52,8 +52,14 @@ jobs:
         run: |
           echo "${{ secrets.ENVS }}" >> .env
           echo "GITHUB_REPOSITORY=${{ github.repository }}" >> .env
-          # Only fill in the tag when the caller didn't already pin a custom OBTAINIUM_GITHUB_TAG via secrets.ENVS.
-          if [ -n "${RELEASE_TAG}" ] && ! grep -q '^OBTAINIUM_GITHUB_TAG=' .env; then
+          # Only fill in the tag when the caller didn't already pin a non-empty custom
+          # OBTAINIUM_GITHUB_TAG via secrets.ENVS. Dotenv semantics: last occurrence of the key
+          # wins, and its value may be quoted/padded with whitespace, so a plain key-presence
+          # grep would wrongly treat `OBTAINIUM_GITHUB_TAG=` (empty) as already pinned. The
+          # trailing `|| true` keeps a no-match grep (the common case) from tripping bash -eo
+          # pipefail, under which run: steps execute by default.
+          existing_tag=$(grep '^OBTAINIUM_GITHUB_TAG=' .env | tail -n1 | cut -d'=' -f2- | sed -e 's/^[[:space:]]*//' -e 's/[[:space:]]*$//' -e "s/^['\"]//" -e "s/['\"]$//" || true)
+          if [ -n "${RELEASE_TAG}" ] && [ -z "${existing_tag}" ]; then
             echo "OBTAINIUM_GITHUB_TAG=${RELEASE_TAG}" >> .env
           fi
 

--- a/.github/workflows/build-artifact.yml
+++ b/.github/workflows/build-artifact.yml
@@ -30,6 +30,10 @@ on:
         description: "Apps to be patched. Overrides any env set"
         required: false
         type: string
+      RELEASE_TAG:
+        description: "GitHub release tag this build will be uploaded under. Used as the Obtainium export tag."
+        required: false
+        type: string
 
 jobs:
   build-apk:
@@ -43,9 +47,15 @@ jobs:
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
 
       - name: Update Env for custom build
+        env:
+          RELEASE_TAG: ${{ inputs.RELEASE_TAG }}
         run: |
           echo "${{ secrets.ENVS }}" >> .env
           echo "GITHUB_REPOSITORY=${{ github.repository }}" >> .env
+          # Only fill in the tag when the caller didn't already pin a custom OBTAINIUM_GITHUB_TAG via secrets.ENVS.
+          if [ -n "${RELEASE_TAG}" ] && ! grep -q '^OBTAINIUM_GITHUB_TAG=' .env; then
+            echo "OBTAINIUM_GITHUB_TAG=${RELEASE_TAG}" >> .env
+          fi
 
       - name: Update Env from secrets for custom build
         run: |


### PR DESCRIPTION
Fixes #852

Compute the release tag once (compute-tag job) and pass it into build-artifact.yml as OBTAINIUM_GITHUB_TAG before main.py runs, so the generated Obtainium sources always point at the release the APK is actually uploaded to instead of falling back to "latest" and pointing at a release that may not contain that app's build.

Also add a DELETE_OLDER_RELEASES input (default true) so callers doing partial builds can skip the "Delete Older Releases" step, since it would otherwise remove releases containing apps not in the current batch. auto-release.yml always does partial builds, so it wires this (and TELEGRAM_NO_ROOT_UPLOAD, which was previously hardcoded and ignored its own input) through a schedule-vs-dispatch aware default kept in one place at the top of the file.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added options to control whether older releases are removed during automated or manual releases.
  - Added support for specifying a custom release tag when building artifacts.
  - Release tags are now generated consistently and shared across build and upload steps.

- **Improvements**
  - Scheduled releases can use their own upload and cleanup preferences.
  - Release uploads now use the same tag as the associated build artifacts.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->