### PR TITLE
Add support PERSONAL_ACCESS_TOKEN as a dedicated Actions secret

### DIFF
--- a/.github/workflows/auto-release.yml
+++ b/.github/workflows/auto-release.yml
@@ -25,8 +25,16 @@ jobs:
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
 
       - name: Update Env for custom build
+        env:
+          PERSONAL_ACCESS_TOKEN: ${{ secrets.PERSONAL_ACCESS_TOKEN }}
         run: |
           echo "${{ secrets.ENVS }}" >> .env
+          # An ENVS-embedded PERSONAL_ACCESS_TOKEN always wins (backwards compat); only fall back
+          # to the secret when unset/empty. `|| true` avoids aborting on a no-match grep (-o pipefail).
+          existing_pat=$(grep '^PERSONAL_ACCESS_TOKEN=' .env | tail -n1 | cut -d'=' -f2- | sed -e 's/^[[:space:]]*//' -e 's/[[:space:]]*$//' -e "s/^['\"]//" -e "s/['\"]$//" || true)
+          if [ -n "${PERSONAL_ACCESS_TOKEN}" ] && [ -z "${existing_pat}" ]; then
+            echo "PERSONAL_ACCESS_TOKEN=${PERSONAL_ACCESS_TOKEN}" >> .env
+          fi
 
       - name: Setup python
         uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0

--- a/.github/workflows/build-apk.yml
+++ b/.github/workflows/build-apk.yml
@@ -93,6 +93,7 @@ jobs:
       ENVS: ${{ secrets.ENVS }}
       DOCKER_PY_REVANCED_SECRETS: ${{ secrets.DOCKER_PY_REVANCED_SECRETS }}
       REDDIT_CLIENT_ID: ${{ secrets.REDDIT_CLIENT_ID }}
+      PERSONAL_ACCESS_TOKEN: ${{ secrets.PERSONAL_ACCESS_TOKEN }}
 
   upload-to-github:
     name: GitHub Upload

--- a/.github/workflows/build-artifact.yml
+++ b/.github/workflows/build-artifact.yml
@@ -50,13 +50,8 @@ jobs:
         run: |
           echo "${{ secrets.ENVS }}" >> .env
           echo "GITHUB_REPOSITORY=${{ github.repository }}" >> .env
-          # Only fill in the token from the dedicated secret when the caller didn't already pin a
-          # non-empty PERSONAL_ACCESS_TOKEN via secrets.ENVS - an ENVS-embedded value always wins,
-          # for backwards compatibility with existing setups. Dotenv semantics: last occurrence of
-          # the key wins, and its value may be quoted/padded with whitespace, so a plain
-          # key-presence grep would wrongly treat `PERSONAL_ACCESS_TOKEN=` (empty) as already
-          # pinned. `|| true` keeps a no-match grep (the common case) from tripping bash -eo
-          # pipefail, under which run: steps execute by default.
+          # An ENVS-embedded PERSONAL_ACCESS_TOKEN always wins (backwards compat); only fall back
+          # to the secret when unset/empty. `|| true` avoids aborting on a no-match grep (-o pipefail).
           existing_pat=$(grep '^PERSONAL_ACCESS_TOKEN=' .env | tail -n1 | cut -d'=' -f2- | sed -e 's/^[[:space:]]*//' -e 's/[[:space:]]*$//' -e "s/^['\"]//" -e "s/['\"]$//" || true)
           if [ -n "${PERSONAL_ACCESS_TOKEN}" ] && [ -z "${existing_pat}" ]; then
             echo "PERSONAL_ACCESS_TOKEN=${PERSONAL_ACCESS_TOKEN}" >> .env

--- a/.github/workflows/build-artifact.yml
+++ b/.github/workflows/build-artifact.yml
@@ -12,6 +12,8 @@ on:
         required: false
       REDDIT_CLIENT_ID:
         required: false
+      PERSONAL_ACCESS_TOKEN:
+        required: false
     inputs:
       CI_TEST:
         required: false
@@ -43,9 +45,22 @@ jobs:
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
 
       - name: Update Env for custom build
+        env:
+          PERSONAL_ACCESS_TOKEN: ${{ secrets.PERSONAL_ACCESS_TOKEN }}
         run: |
           echo "${{ secrets.ENVS }}" >> .env
           echo "GITHUB_REPOSITORY=${{ github.repository }}" >> .env
+          # Only fill in the token from the dedicated secret when the caller didn't already pin a
+          # non-empty PERSONAL_ACCESS_TOKEN via secrets.ENVS - an ENVS-embedded value always wins,
+          # for backwards compatibility with existing setups. Dotenv semantics: last occurrence of
+          # the key wins, and its value may be quoted/padded with whitespace, so a plain
+          # key-presence grep would wrongly treat `PERSONAL_ACCESS_TOKEN=` (empty) as already
+          # pinned. `|| true` keeps a no-match grep (the common case) from tripping bash -eo
+          # pipefail, under which run: steps execute by default.
+          existing_pat=$(grep '^PERSONAL_ACCESS_TOKEN=' .env | tail -n1 | cut -d'=' -f2- | sed -e 's/^[[:space:]]*//' -e 's/[[:space:]]*$//' -e "s/^['\"]//" -e "s/['\"]$//" || true)
+          if [ -n "${PERSONAL_ACCESS_TOKEN}" ] && [ -z "${existing_pat}" ]; then
+            echo "PERSONAL_ACCESS_TOKEN=${PERSONAL_ACCESS_TOKEN}" >> .env
+          fi
 
       - name: Update Env from secrets for custom build
         run: |

--- a/README.md
+++ b/README.md
@@ -305,6 +305,9 @@ You can use any of the following methods to build.
    ```dotenv
     PERSONAL_ACCESS_TOKEN=<PAT>
    ```
+   Alternatively, you can add a dedicated `PERSONAL_ACCESS_TOKEN` secret to the repo (`Settings` ->
+   `Secrets and variables` -> `Actions`) instead of embedding it in `ENVS`. It's used automatically unless
+   `ENVS` already sets `PERSONAL_ACCESS_TOKEN` to a non-empty value, in which case `ENVS` takes priority.
 7. <a id="global-resources"></a>You can provide Direct download to the resource to used for patching apps `.env` file
    or in `ENVS` in `GitHub secrets` (Recommended) in the format -
    ```dotenv


### PR DESCRIPTION
## Summary

GitHub Actions secrets can't be edited, only overwritten, so it's often useful to keep a backup copy of the `ENVS` secret somewhere (e.g. locally, or for reference when rebuilding it). But `ENVS` currently has to contain `PERSONAL_ACCESS_TOKEN` as a literal embedded line if you want the higher API rate limits, which makes keeping a copy of `ENVS` risky, and remembering to re-add the PAT every time it's rebuilt is easy to forget.

This adds support for a dedicated `PERSONAL_ACCESS_TOKEN` repo secret as an alternative, so the PAT can live separately from `ENVS` - keeping `ENVS` itself less sensitive and safer to copy/share in most cases.

- `build-artifact.yml`: declares `PERSONAL_ACCESS_TOKEN` as an optional `workflow_call` secret. The "Update Env for custom build" step appends it to `.env`, but only when `ENVS` hasn't already pinned a non-empty `PERSONAL_ACCESS_TOKEN` - so existing setups that embed it in `ENVS` keep working unchanged and take priority (backwards compatible).
- `build-apk.yml`: threads `secrets.PERSONAL_ACCESS_TOKEN` through to `build-artifact.yml`.
- `README.md`: documents the new secret as an alternative to embedding it in `ENVS`, noting `ENVS` still wins.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * GitHub Actions builds and releases can now automatically use a dedicated personal access token when none is already configured.

* **Documentation**
  * Added setup guidance covering repository secret configuration and token precedence.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->