### PR TITLE
Generate one-click Obtainium install links for GitHub Pages

### DIFF
--- a/.github/workflows/build-artifact.yml
+++ b/.github/workflows/build-artifact.yml
@@ -169,6 +169,6 @@ jobs:
         with:
           branch: changelogs
           skip_checkout: true
-          file_pattern: 'changelog.md changelog.json updates.json obtainium_sources/*'
+          file_pattern: 'changelog.md changelog.json updates.json obtainium_sources/* index.html'
           commit_message: 🚀New Build
           push_options: '--force'

--- a/README.md
+++ b/README.md
@@ -173,7 +173,7 @@ full option details.
 |:----------------------------------------------------------------------------------|:--------------------------------------------------------------:|:-------------|
 | [OBTAINIUM_EXPORT](obtainium.md#obtainium_export)                                 |            Generate per-app HTML sources for Obtainium         | False        |
 | [OBTAINIUM_GITHUB_TAG](obtainium.md#obtainium_github_tag)                         |         Release tag the generated links point to               | latest       |
-| [OBTAINIUM_SITE_EXPORT](obtainium.md#obtainium_site_export)                       |    Generate a one-click install site (`obtainium_sources/index.html`) | False  |
+| [OBTAINIUM_SITE_EXPORT](obtainium.md#obtainium_site_export)                       |    Generate a one-click install site (`index.html` at branch root) | False  |
 | [OBTAINIUM_VERSION_EXTRACTION_REGEX](obtainium.md#obtainium_version_extraction_regex) | Regex used to extract app + patch version for display     | See docs     |
 | [OBTAINIUM_VERSION_MATCH_GROUP](obtainium.md#obtainium_version_match_group)       |         Match-group template used with the regex above         | `$1+$2`      |
 

--- a/README.md
+++ b/README.md
@@ -163,6 +163,20 @@ You can use any of the following methods to build.
 `**` - Can be used to included universal patch.<br>
 `***` - Can be used for unavailable apps in the repository (unofficial apps).
 
+### Obtainium
+
+Optional integration with [Obtainium](https://github.com/ImranR98/Obtainium) so patched APKs can be installed and
+updated straight from your GitHub Releases. See [obtainium.md](obtainium.md) for setup steps, how it works, and
+full option details.
+
+| **Env Name**                                                                     |                       **Description**                        | **Default** |
+|:----------------------------------------------------------------------------------|:--------------------------------------------------------------:|:-------------|
+| [OBTAINIUM_EXPORT](obtainium.md#obtainium_export)                                 |            Generate per-app HTML sources for Obtainium         | False        |
+| [OBTAINIUM_GITHUB_TAG](obtainium.md#obtainium_github_tag)                         |         Release tag the generated links point to               | latest       |
+| [OBTAINIUM_SITE_EXPORT](obtainium.md#obtainium_site_export)                       |    Generate a one-click install site (`obtainium_sources/index.html`) | False  |
+| [OBTAINIUM_VERSION_EXTRACTION_REGEX](obtainium.md#obtainium_version_extraction_regex) | Regex used to extract app + patch version for display     | See docs     |
+| [OBTAINIUM_VERSION_MATCH_GROUP](obtainium.md#obtainium_version_match_group)       |         Match-group template used with the regex above         | `$1+$2`      |
+
 ## Note
 
 1. <a id="any-patch-apps"></a>**Officially** Supported values for **APP_NAME**** are :
@@ -538,42 +552,4 @@ You can use any of the following methods to build.
     APPRISE_URL=tgram://bot-token/chat-id
     APPRISE_NOTIFICATION_BODY=What a great Body
     APPRISE_NOTIFICATION_TITLE=What a great title
-    ```
-
-20. <a id="obtainium"></a>[Obtainium](https://github.com/ImranR98/Obtainium)<br>
-    We support generating HTML files for Obtainium to scrape and download the latest patched APKs directly from your GitHub Releases.
-    Enable this only when you are comfortable exposing a public APK discovery URL for your fork or self-hosted setup.
-    Add below envs in `.env` file or in `ENVS` in `GitHub secrets` (Recommended) in the format
-    ```ini
-    OBTAINIUM_EXPORT=true
-    ```
-    This will generate an `obtainium_sources/` folder in the `changelogs` branch containing HTML files (e.g., `youtube.html`).
-    You can then add the raw GitHub URL of these HTML files to Obtainium as an "HTML" source.
-    Example URL: `https://raw.githubusercontent.com/<user>/<repo>/changelogs/obtainium_sources/youtube.html`
-    Obtainium's HTML source can use the APK link hash as its release ID, so patch-only updates are detected through
-    the generated release asset name without requiring a custom version extraction regex.
-
-    **Optional Configuration**:
-    ```ini
-    OBTAINIUM_GITHUB_TAG=latest
-    ```
-    By default, links point to the `latest` release. If you want to link to a specific tag, set this variable.
-    > **Warning**: Ensure your CI workflow is configured to release with the exact tag you specify. The default CI uses dynamic timestamp-based tags.
-
-    **One-click install site**:
-    ```ini
-    OBTAINIUM_SITE_EXPORT=true
-    ```
-    In addition to the per-app HTML files, this generates `obtainium_sources/index.html` with an
-    `obtainium://app/...` deep link for each app - tapping one on an Android device with Obtainium installed adds
-    that app's source with no manual configuration. Point GitHub Pages at the `changelogs` branch,
-    `/obtainium_sources` folder to publish it (the missing `index.html` is why this previously didn't work when
-    pointing Pages at that folder).
-
-    The generated links include a version extraction regex so Obtainium shows a readable version instead of a
-    hash. The default matches this project's own output filename convention and needs no configuration; override
-    it only if you've customized the build's filename format:
-    ```ini
-    OBTAINIUM_VERSION_EXTRACTION_REGEX=Version([\w.]+)-PatchVersion[v]?([\w.]+)-PatchSet
-    OBTAINIUM_VERSION_MATCH_GROUP=$1+$2
     ```

--- a/README.md
+++ b/README.md
@@ -559,3 +559,21 @@ You can use any of the following methods to build.
     ```
     By default, links point to the `latest` release. If you want to link to a specific tag, set this variable.
     > **Warning**: Ensure your CI workflow is configured to release with the exact tag you specify. The default CI uses dynamic timestamp-based tags.
+
+    **One-click install site**:
+    ```ini
+    OBTAINIUM_SITE_EXPORT=true
+    ```
+    In addition to the per-app HTML files, this generates `obtainium_sources/index.html` with an
+    `obtainium://app/...` deep link for each app - tapping one on an Android device with Obtainium installed adds
+    that app's source with no manual configuration. Point GitHub Pages at the `changelogs` branch,
+    `/obtainium_sources` folder to publish it (the missing `index.html` is why this previously didn't work when
+    pointing Pages at that folder).
+
+    The generated links include a version extraction regex so Obtainium shows a readable version instead of a
+    hash. The default matches this project's own output filename convention and needs no configuration; override
+    it only if you've customized the build's filename format:
+    ```ini
+    OBTAINIUM_VERSION_EXTRACTION_REGEX=Version([\w.]+)-PatchVersion[v]?([\w.]+)-PatchSet
+    OBTAINIUM_VERSION_MATCH_GROUP=$1+$2
+    ```

--- a/obtainium.md
+++ b/obtainium.md
@@ -15,11 +15,15 @@ Two things get generated, and the second builds on the first:
 1. **Per-app HTML source pages** (`OBTAINIUM_EXPORT`) - one static HTML file per patched app, containing a link to
    its latest release asset. Obtainium's "HTML" source type can point at a page like this and periodically re-check
    it for updates, the same way it'd scrape any other HTML page.
-2. **One-click install site** (`OBTAINIUM_SITE_EXPORT`) - an index page listing every app, each as an
+2. **One-click install site** (`OBTAINIUM_SITE_EXPORT`) - an `index.html` at the repo root of the `changelogs`
+   branch, listing every app as an
    [`obtainium://app/...`](https://github.com/ImranR98/Obtainium/blob/main/README.md) deep link. These links carry
    a URL-encoded JSON blob of an app's full Obtainium configuration (source URL, author, name, version regex,
    etc.). Tapping one on a device with Obtainium installed opens the app with that config pre-filled - equivalent
    to manually adding the HTML source from step 1 and typing in all the same settings by hand, minus the typing.
+   It's written at the branch root rather than alongside the per-app pages in `obtainium_sources/` because GitHub
+   Pages' branch-deploy mode can only serve from a branch's root or its `/docs` folder, never an arbitrary
+   subfolder.
 
 Version detection deserves a specific callout, since it's the part most likely to need tuning: the per-app HTML
 page's only meaningful content is a link to the release asset, and that asset's filename already encodes the app
@@ -43,11 +47,12 @@ have to configure this same regex by hand in Obtainium's UI.
    - **Manually**: in Obtainium, add each app via its raw HTML URL as an "HTML" source, e.g.
      `https://raw.githubusercontent.com/<user>/<repo>/changelogs/obtainium_sources/youtube.html`. You'll need to
      configure the version regex yourself if you want readable versions (see above).
-   - **One-click site**: also enable `OBTAINIUM_SITE_EXPORT=true`. This additionally generates
-     `obtainium_sources/index.html` with a ready-to-tap link per app, version regex included.
+   - **One-click site**: also enable `OBTAINIUM_SITE_EXPORT=true`. This additionally generates `index.html` at
+     the `changelogs` branch root with a ready-to-tap link per app, version regex included.
 3. *(Optional, for the one-click site)* Publish it with GitHub Pages: repo Settings -> Pages -> set the source
-   branch to `changelogs` and the folder to `/obtainium_sources`. Visit the published Pages URL on an Android
-   device with Obtainium installed and tap the links you want.
+   branch to `changelogs` and the folder to `/ (root)` - GitHub Pages' branch-deploy mode only offers root or
+   `/docs`, so this only works because `index.html` is generated at the branch root. Visit the published Pages
+   URL on an Android device with Obtainium installed and tap the links you want.
 
 ## Configuration
 
@@ -82,8 +87,9 @@ OBTAINIUM_GITHUB_TAG=latest
 ### `OBTAINIUM_SITE_EXPORT`
 
 - **Default**: `false`
-- Generates `obtainium_sources/index.html`, listing a one-click `obtainium://app/...` install link for every app
-  covered by `OBTAINIUM_EXPORT`. See [How it works](#how-it-works) above for what these links contain.
+- Generates `index.html` at the `changelogs` branch root, listing a one-click `obtainium://app/...` install link
+  for every app covered by `OBTAINIUM_EXPORT`. See [How it works](#how-it-works) above for what these links
+  contain and why it's at the branch root rather than inside `obtainium_sources/`.
 
 ```ini
 OBTAINIUM_SITE_EXPORT=true

--- a/obtainium.md
+++ b/obtainium.md
@@ -1,0 +1,117 @@
+# Obtainium
+
+[Obtainium](https://github.com/ImranR98/Obtainium) is an Android app that installs and updates apps straight from
+their source (GitHub releases, F-Droid, direct APK links, arbitrary HTML pages, etc.), skipping app stores
+entirely. Since this project's own releases are just GitHub Releases, Obtainium can track them directly - this
+integration exists to make setting that up (and keeping version numbers readable) less manual.
+
+> **Warning**: Enabling any of this generates a public APK discovery URL for your fork or self-hosted setup. Only
+> enable it if you're comfortable with that.
+
+## How it works
+
+Two things get generated, and the second builds on the first:
+
+1. **Per-app HTML source pages** (`OBTAINIUM_EXPORT`) - one static HTML file per patched app, containing a link to
+   its latest release asset. Obtainium's "HTML" source type can point at a page like this and periodically re-check
+   it for updates, the same way it'd scrape any other HTML page.
+2. **One-click install site** (`OBTAINIUM_SITE_EXPORT`) - an index page listing every app, each as an
+   [`obtainium://app/...`](https://github.com/ImranR98/Obtainium/blob/main/README.md) deep link. These links carry
+   a URL-encoded JSON blob of an app's full Obtainium configuration (source URL, author, name, version regex,
+   etc.). Tapping one on a device with Obtainium installed opens the app with that config pre-filled - equivalent
+   to manually adding the HTML source from step 1 and typing in all the same settings by hand, minus the typing.
+
+Version detection deserves a specific callout, since it's the part most likely to need tuning: the per-app HTML
+page's only meaningful content is a link to the release asset, and that asset's filename already encodes the app
+version and patch bundle version (see `APP.get_output_file_name` in `src/app.py`), e.g.:
+
+```text
+ReYouTube-Version20.47.62-PatchVersionv1.37.0-PatchSetabc123def456-2026AUG01.0131AM-output.apk
+```
+
+Obtainium can apply a regex against that link text to pull out a human-readable version instead of falling back to
+hashing the link (which still works, just shows a hash instead of a version). `OBTAINIUM_VERSION_EXTRACTION_REGEX`
+and `OBTAINIUM_VERSION_MATCH_GROUP` (see below) control that regex, and the deep links from `OBTAINIUM_SITE_EXPORT`
+pre-fill it automatically. If you add a source manually via its HTML URL instead of via a deep link, you'd otherwise
+have to configure this same regex by hand in Obtainium's UI.
+
+## Setup
+
+1. Enable `OBTAINIUM_EXPORT=true` (see [Configuration](#configuration) below). This is the minimum needed - it
+   generates `obtainium_sources/*.html` in the `changelogs` branch, one file per patched app.
+2. Add sources to Obtainium one of two ways:
+   - **Manually**: in Obtainium, add each app via its raw HTML URL as an "HTML" source, e.g.
+     `https://raw.githubusercontent.com/<user>/<repo>/changelogs/obtainium_sources/youtube.html`. You'll need to
+     configure the version regex yourself if you want readable versions (see above).
+   - **One-click site**: also enable `OBTAINIUM_SITE_EXPORT=true`. This additionally generates
+     `obtainium_sources/index.html` with a ready-to-tap link per app, version regex included.
+3. *(Optional, for the one-click site)* Publish it with GitHub Pages: repo Settings -> Pages -> set the source
+   branch to `changelogs` and the folder to `/obtainium_sources`. Visit the published Pages URL on an Android
+   device with Obtainium installed and tap the links you want.
+
+## Configuration
+
+Add these to your `.env` file, or (recommended) to the `ENVS` GitHub secret.
+
+<a id="obtainium_export"></a>
+### `OBTAINIUM_EXPORT`
+
+- **Default**: `false`
+- Generates `obtainium_sources/*.html` (one file per patched app) in the `changelogs` branch. Required for
+  everything else in this document; the rest of these variables have no effect unless this is enabled.
+
+```ini
+OBTAINIUM_EXPORT=true
+```
+
+<a id="obtainium_github_tag"></a>
+### `OBTAINIUM_GITHUB_TAG`
+
+- **Default**: `latest`
+- The release tag the generated HTML links point to. By default, links point at `latest` so they survive the
+  default CI's dynamic timestamp-based release tags.
+
+```ini
+OBTAINIUM_GITHUB_TAG=latest
+```
+
+> **Warning**: If you set this to a fixed tag, make sure your CI workflow actually releases under that exact tag -
+> otherwise the generated links will point at a release that doesn't exist (or doesn't contain that app's APK).
+
+<a id="obtainium_site_export"></a>
+### `OBTAINIUM_SITE_EXPORT`
+
+- **Default**: `false`
+- Generates `obtainium_sources/index.html`, listing a one-click `obtainium://app/...` install link for every app
+  covered by `OBTAINIUM_EXPORT`. See [How it works](#how-it-works) above for what these links contain.
+
+```ini
+OBTAINIUM_SITE_EXPORT=true
+```
+
+<a id="obtainium_version_extraction_regex"></a>
+### `OBTAINIUM_VERSION_EXTRACTION_REGEX`
+
+- **Default**: `Version([\w.]+)-PatchVersion[v]?([\w.]+)-PatchSet`
+- The regex Obtainium applies to the release asset link text to extract version info, embedded into each
+  `OBTAINIUM_SITE_EXPORT` deep link's `additionalSettings.versionExtractionRegEx`. The default matches this
+  project's own output filename convention (app version, then patch bundle version - with or without a leading
+  `v`, since that varies by patch source) and needs no configuration out of the box. Only override this if you've
+  customized the build's output filename format elsewhere.
+
+```ini
+OBTAINIUM_VERSION_EXTRACTION_REGEX=Version([\w.]+)-PatchVersion[v]?([\w.]+)-PatchSet
+```
+
+<a id="obtainium_version_match_group"></a>
+### `OBTAINIUM_VERSION_MATCH_GROUP`
+
+- **Default**: `$1+$2`
+- The match-group template Obtainium uses to assemble the extracted version, embedded into each deep link's
+  `additionalSettings.matchGroupToUse`. The default combines the app version and patch version (regex groups 1 and
+  2 above) into a single `<app_version>+<patch_version>` string. Only override this if you've also changed
+  `OBTAINIUM_VERSION_EXTRACTION_REGEX` and need a different group arrangement.
+
+```ini
+OBTAINIUM_VERSION_MATCH_GROUP=$1+$2
+```

--- a/src/config.py
+++ b/src/config.py
@@ -45,3 +45,11 @@ class RevancedConfig(object):
         self.disable_caching = env.bool("DISABLE_CACHING", False)
         self.obtainium_export = env.bool("OBTAINIUM_EXPORT", False)
         self.obtainium_github_tag = env.str("OBTAINIUM_GITHUB_TAG", "latest")
+        self.obtainium_site_export = env.bool("OBTAINIUM_SITE_EXPORT", False)
+        # Matches this project's own output filename convention (see APP.get_output_file_name),
+        # so version + patch bundle version resolve correctly without extra configuration.
+        self.obtainium_version_extraction_regex = env.str(
+            "OBTAINIUM_VERSION_EXTRACTION_REGEX",
+            r"Version([\w.]+)-PatchVersion[v]?([\w.]+)-PatchSet",
+        )
+        self.obtainium_version_match_group = env.str("OBTAINIUM_VERSION_MATCH_GROUP", "$1+$2")

--- a/src/utils.py
+++ b/src/utils.py
@@ -335,8 +335,12 @@ def _obtainium_deep_link(
     return "obtainium://app/" + quote(json.dumps(app_config, separators=(",", ":")), safe="")
 
 
-def _write_obtainium_index(obtainium_sources_path: Path, apps: list[tuple[str, str]]) -> None:
-    """Write a styled index page of one-click Obtainium "Add app" links, e.g. for GitHub Pages."""
+def _write_obtainium_index(apps: list[tuple[str, str]]) -> None:
+    """Write a styled index page of one-click Obtainium "Add app" links.
+
+    Written to the repo root (not obtainium_sources/) because GitHub Pages' branch-deploy mode can only
+    serve from a branch's root or its /docs folder - never an arbitrary subfolder.
+    """
     rows = "\n".join(
         f"""        <li class="app-row">
             <span class="app-name">{name}</span>
@@ -428,7 +432,7 @@ def _write_obtainium_index(obtainium_sources_path: Path, apps: list[tuple[str, s
 </body>
 </html>
 """
-    index_path = obtainium_sources_path / "index.html"
+    index_path = Path("index.html")
     index_path.write_text(html_content.strip(), encoding="utf_8")
     logger.info(f"Generated Obtainium site index: {index_path}")
 
@@ -515,4 +519,4 @@ def generate_obtainium_export(updates_info: dict[str, Any], config: "RevancedCon
                 deep_links.append((display_app_name, deep_link))
 
     if config.obtainium_site_export and deep_links:
-        _write_obtainium_index(obtainium_sources_path, deep_links)
+        _write_obtainium_index(deep_links)

--- a/src/utils.py
+++ b/src/utils.py
@@ -336,8 +336,14 @@ def _obtainium_deep_link(
 
 
 def _write_obtainium_index(obtainium_sources_path: Path, apps: list[tuple[str, str]]) -> None:
-    """Write an index page of one-click Obtainium "Add app" links, e.g. for GitHub Pages."""
-    rows = "\n".join(f'        <li><a href="{link}">Add {name} to Obtainium</a></li>' for name, link in apps)
+    """Write a styled index page of one-click Obtainium "Add app" links, e.g. for GitHub Pages."""
+    rows = "\n".join(
+        f"""        <li class="app-row">
+            <span class="app-name">{name}</span>
+            <a class="add-button" href="{link}">Add to Obtainium</a>
+        </li>"""
+        for name, link in apps
+    )
     html_content = f"""
 <!DOCTYPE html>
 <html lang="en">
@@ -345,12 +351,80 @@ def _write_obtainium_index(obtainium_sources_path: Path, apps: list[tuple[str, s
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>Obtainium Sources</title>
+    <style>
+        :root {{
+            color-scheme: light dark;
+            --bg: #f5f6f8;
+            --card-bg: #ffffff;
+            --text: #1a1a1a;
+            --muted: #5f6368;
+            --accent: #2f6fed;
+            --accent-text: #ffffff;
+            --border: #e2e4e8;
+        }}
+        @media (prefers-color-scheme: dark) {{
+            :root {{
+                --bg: #16171a;
+                --card-bg: #212226;
+                --text: #f1f2f4;
+                --muted: #9aa0a6;
+                --accent: #6f9dff;
+                --accent-text: #0b0d10;
+                --border: #33353a;
+            }}
+        }}
+        * {{ box-sizing: border-box; }}
+        body {{
+            margin: 0;
+            padding: 2rem 1rem 3rem;
+            background: var(--bg);
+            color: var(--text);
+            font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Helvetica, Arial, sans-serif;
+        }}
+        main {{ max-width: 640px; margin: 0 auto; }}
+        h1 {{ font-size: 1.5rem; margin-bottom: 0.25rem; }}
+        p.intro {{ color: var(--muted); line-height: 1.5; margin-top: 0; }}
+        p.intro a {{ color: var(--accent); text-decoration: none; }}
+        p.intro a:hover {{ text-decoration: underline; }}
+        ul {{ list-style: none; padding: 0; margin: 1.5rem 0 0; display: flex; flex-direction: column; gap: 0.75rem; }}
+        .app-row {{
+            display: flex;
+            align-items: center;
+            justify-content: space-between;
+            gap: 1rem;
+            background: var(--card-bg);
+            border: 1px solid var(--border);
+            border-radius: 12px;
+            padding: 0.9rem 1.1rem;
+        }}
+        .app-name {{ font-weight: 600; overflow-wrap: anywhere; }}
+        .add-button {{
+            flex-shrink: 0;
+            display: inline-block;
+            background: var(--accent);
+            color: var(--accent-text);
+            text-decoration: none;
+            font-weight: 600;
+            font-size: 0.9rem;
+            padding: 0.5rem 0.9rem;
+            border-radius: 8px;
+            white-space: nowrap;
+        }}
+        .add-button:hover {{ opacity: 0.9; }}
+    </style>
 </head>
 <body>
-    <h1>Obtainium Sources</h1>
-    <ul>
+    <main>
+        <h1>Obtainium Sources</h1>
+        <p class="intro">
+            Tap a button below on an Android device with
+            <a href="https://github.com/ImranR98/Obtainium">Obtainium</a> installed to add that app as an update
+            source. Don't have it yet? Get it from the link above first.
+        </p>
+        <ul>
 {rows}
-    </ul>
+        </ul>
+    </main>
 </body>
 </html>
 """

--- a/src/utils.py
+++ b/src/utils.py
@@ -335,18 +335,28 @@ def _obtainium_deep_link(
     return "obtainium://app/" + quote(json.dumps(app_config, separators=(",", ":")), safe="")
 
 
-def _write_obtainium_index(apps: list[tuple[str, str]]) -> None:
+def _write_obtainium_index(cards: list[dict[str, str]]) -> None:
     """Write a styled index page of one-click Obtainium "Add app" links.
 
     Written to the repo root (not obtainium_sources/) because GitHub Pages' branch-deploy mode can only
     serve from a branch's root or its /docs folder - never an arbitrary subfolder.
     """
     rows = "\n".join(
-        f"""        <li class="app-row">
-            <span class="app-name">{name}</span>
-            <a class="add-button" href="{link}">Add to Obtainium</a>
+        f"""        <li class="app-card">
+            <div class="app-header">
+                <span class="app-name">{card["name"]}</span>
+                <code class="package-name">{card["package_name"]}</code>
+            </div>
+            <div class="app-meta">
+                <span class="meta-chip">App {card["app_version"]}</span>
+                <span class="meta-chip">Patch {card["patch_version"]}</span>
+            </div>
+            <div class="app-actions">
+                <a class="add-button" href="{card["deep_link"]}">Add to Obtainium</a>
+                <a class="source-link" href="{card["source_url"]}">View source</a>
+            </div>
         </li>"""
-        for name, link in apps
+        for card in cards
     )
     html_content = f"""
 <!DOCTYPE html>
@@ -391,17 +401,39 @@ def _write_obtainium_index(apps: list[tuple[str, str]]) -> None:
         p.intro a {{ color: var(--accent); text-decoration: none; }}
         p.intro a:hover {{ text-decoration: underline; }}
         ul {{ list-style: none; padding: 0; margin: 1.5rem 0 0; display: flex; flex-direction: column; gap: 0.75rem; }}
-        .app-row {{
+        .app-card {{
             display: flex;
-            align-items: center;
-            justify-content: space-between;
-            gap: 1rem;
+            flex-direction: column;
+            gap: 0.6rem;
             background: var(--card-bg);
             border: 1px solid var(--border);
             border-radius: 12px;
             padding: 0.9rem 1.1rem;
         }}
+        .app-header {{
+            display: flex;
+            align-items: baseline;
+            flex-wrap: wrap;
+            gap: 0.5rem;
+        }}
         .app-name {{ font-weight: 600; overflow-wrap: anywhere; }}
+        .package-name {{
+            font-size: 0.8rem;
+            color: var(--muted);
+            font-family: ui-monospace, SFMono-Regular, Menlo, Consolas, monospace;
+            overflow-wrap: anywhere;
+        }}
+        .app-meta {{ display: flex; flex-wrap: wrap; gap: 0.4rem; }}
+        .meta-chip {{
+            font-size: 0.78rem;
+            color: var(--muted);
+            background: var(--bg);
+            border: 1px solid var(--border);
+            border-radius: 999px;
+            padding: 0.15rem 0.6rem;
+            font-variant-numeric: tabular-nums;
+        }}
+        .app-actions {{ display: flex; align-items: center; flex-wrap: wrap; gap: 0.75rem; margin-top: 0.2rem; }}
         .add-button {{
             flex-shrink: 0;
             display: inline-block;
@@ -415,6 +447,12 @@ def _write_obtainium_index(apps: list[tuple[str, str]]) -> None:
             white-space: nowrap;
         }}
         .add-button:hover {{ opacity: 0.9; }}
+        .source-link {{
+            font-size: 0.85rem;
+            color: var(--muted);
+            text-decoration: none;
+        }}
+        .source-link:hover {{ color: var(--accent); text-decoration: underline; }}
     </style>
 </head>
 <body>
@@ -453,7 +491,7 @@ def generate_obtainium_export(updates_info: dict[str, Any], config: "RevancedCon
         logger.warning("GITHUB_REPOSITORY not set. Skipping Obtainium export.")
         return
 
-    deep_links: list[tuple[str, str]] = []
+    site_cards: list[dict[str, str]] = []
 
     for app_name, app_data in updates_info.items():
         if "output_file_name" not in app_data:
@@ -516,7 +554,17 @@ def generate_obtainium_export(updates_info: dict[str, Any], config: "RevancedCon
                     source_url=source_url,
                     config=config,
                 )
-                deep_links.append((display_app_name, deep_link))
+                patch_versions = ", ".join(str(v) for v in app_data.get(patches_versions_key, [])) or "unknown"
+                site_cards.append(
+                    {
+                        "name": display_app_name,
+                        "package_name": html.escape(package_name),
+                        "app_version": display_version,
+                        "patch_version": html.escape(patch_versions),
+                        "deep_link": deep_link,
+                        "source_url": html.escape(source_url),
+                    },
+                )
 
-    if config.obtainium_site_export and deep_links:
-        _write_obtainium_index(deep_links)
+    if config.obtainium_site_export and site_cards:
+        _write_obtainium_index(site_cards)

--- a/src/utils.py
+++ b/src/utils.py
@@ -62,6 +62,7 @@ apkmirror_scraper = cloudscraper.create_scraper()
 apkmirror_scraper.headers.update({"User-Agent": request_header["User-Agent"]})
 updates_file = "updates.json"
 updates_file_url = "https://raw.githubusercontent.com/{github_repository}/{branch_name}/{updates_file}"
+obtainium_source_url = "https://raw.githubusercontent.com/{github_repository}/{branch_name}/obtainium_sources/{file_name}"
 changelogs: dict[str, dict[str, str]] = {}
 time_zone = "Asia/Kolkata"
 app_version_key = "app_version"
@@ -299,6 +300,65 @@ def save_patch_info(app: "APP", updates_info: dict[str, Any]) -> dict[str, Any]:
     return updates_info
 
 
+def _obtainium_deep_link(
+    *,
+    package_name: str,
+    app_name: str,
+    author: str,
+    source_url: str,
+    config: "RevancedConfig",
+) -> str:
+    """Build an obtainium://app/... link that pre-fills an HTML source, so adding it is one tap."""
+    additional_settings = {
+        "trackOnly": False,
+        "versionExtractionRegEx": config.obtainium_version_extraction_regex,
+        "matchGroupToUse": config.obtainium_version_match_group,
+        "versionDetection": bool(config.obtainium_version_extraction_regex),
+        "apkFilterRegEx": "",
+        "invertAPKFilter": False,
+        "autoApkFilterByArch": True,
+        "appName": app_name,
+        "appAuthor": author,
+        "about": "",
+    }
+    app_config = {
+        "id": package_name,
+        "url": source_url,
+        "author": author,
+        "name": app_name,
+        "preferredApkIndex": 0,
+        "additionalSettings": json.dumps(additional_settings, separators=(",", ":")),
+        "overrideSource": "HTML",
+    }
+    # Compact separators keep the link shorter, matching what Obtainium itself produces.
+    # quote(..., safe="") never leaves a literal `"` in the output, so this is safe to drop straight into an href.
+    return "obtainium://app/" + quote(json.dumps(app_config, separators=(",", ":")), safe="")
+
+
+def _write_obtainium_index(obtainium_sources_path: Path, apps: list[tuple[str, str]]) -> None:
+    """Write an index page of one-click Obtainium "Add app" links, e.g. for GitHub Pages."""
+    rows = "\n".join(f'        <li><a href="{link}">Add {name} to Obtainium</a></li>' for name, link in apps)
+    html_content = f"""
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Obtainium Sources</title>
+</head>
+<body>
+    <h1>Obtainium Sources</h1>
+    <ul>
+{rows}
+    </ul>
+</body>
+</html>
+"""
+    index_path = obtainium_sources_path / "index.html"
+    index_path.write_text(html_content.strip(), encoding="utf_8")
+    logger.info(f"Generated Obtainium site index: {index_path}")
+
+
 def generate_obtainium_export(updates_info: dict[str, Any], config: "RevancedConfig") -> None:
     """Generate HTML files for Obtainium."""
     if not config.obtainium_export:
@@ -309,10 +369,13 @@ def generate_obtainium_export(updates_info: dict[str, Any], config: "RevancedCon
 
     github_repository = config.env.str("GITHUB_REPOSITORY", "")
     obtainium_github_tag = config.obtainium_github_tag
+    repo_owner = github_repository.split("/")[0] if github_repository else ""
 
     if not github_repository:
         logger.warning("GITHUB_REPOSITORY not set. Skipping Obtainium export.")
         return
+
+    deep_links: list[tuple[str, str]] = []
 
     for app_name, app_data in updates_info.items():
         if "output_file_name" not in app_data:
@@ -359,3 +422,23 @@ def generate_obtainium_export(updates_info: dict[str, Any], config: "RevancedCon
         html_file_path = obtainium_sources_path / html_file_name
         html_file_path.write_text(html_content.strip(), encoding="utf_8")
         logger.info(f"Generated Obtainium export for {app_name}: {html_file_path}")
+
+        if config.obtainium_site_export:
+            package_name = str(app_data["app_dump"].get("package_name", ""))
+            if not package_name:
+                logger.warning(f"No package_name for {app_name}. Skipping its Obtainium deep link.")
+            else:
+                source_url = obtainium_source_url.format(
+                    github_repository=github_repository, branch_name=branch_name, file_name=html_file_name,
+                )
+                deep_link = _obtainium_deep_link(
+                    package_name=package_name,
+                    app_name=str(app_name),
+                    author=repo_owner,
+                    source_url=source_url,
+                    config=config,
+                )
+                deep_links.append((display_app_name, deep_link))
+
+    if config.obtainium_site_export and deep_links:
+        _write_obtainium_index(obtainium_sources_path, deep_links)

--- a/tests/test_obtainium_export.py
+++ b/tests/test_obtainium_export.py
@@ -116,6 +116,7 @@ class ObtainiumExportTests(TestCase):
             updates_info = {
                 "YouTube": {
                     "app_version": "20.47.62",
+                    "patches_versions": ["v1.0.0"],
                     "output_file_name": "ReYouTube-Version20.47.62-PatchVersionv1.0.0-PatchSetabc123-output.apk",
                     "app_dump": {"package_name": "app.revanced.android.youtube"},
                 },
@@ -125,6 +126,14 @@ class ObtainiumExportTests(TestCase):
             index_content = Path(temp_dir, "index.html").read_text(encoding="utf_8")
 
         self.assertIn('<span class="app-name">YouTube</span>', index_content)
+        self.assertIn('<code class="package-name">app.revanced.android.youtube</code>', index_content)
+        self.assertIn('<span class="meta-chip">App 20.47.62</span>', index_content)
+        self.assertIn('<span class="meta-chip">Patch v1.0.0</span>', index_content)
+        self.assertIn(
+            'class="source-link" href="https://raw.githubusercontent.com/owner/repo/changelogs/'
+            'obtainium_sources/youtube.html"',
+            index_content,
+        )
         self.assertIn("https://github.com/ImranR98/Obtainium", index_content)
         deep_link_match = re.search(r'href="(obtainium://app/[^"]+)"', index_content)
         self.assertIsNotNone(deep_link_match)

--- a/tests/test_obtainium_export.py
+++ b/tests/test_obtainium_export.py
@@ -124,9 +124,11 @@ class ObtainiumExportTests(TestCase):
             generate_obtainium_export(updates_info, config)
             index_content = Path(temp_dir, "obtainium_sources", "index.html").read_text(encoding="utf_8")
 
-        self.assertIn("Add YouTube to Obtainium", index_content)
-        deep_link = index_content.split('href="')[1].split('"')[0]
-        payload = json.loads(unquote(deep_link.removeprefix("obtainium://app/")))
+        self.assertIn('<span class="app-name">YouTube</span>', index_content)
+        self.assertIn("https://github.com/ImranR98/Obtainium", index_content)
+        deep_link_match = re.search(r'href="(obtainium://app/[^"]+)"', index_content)
+        self.assertIsNotNone(deep_link_match)
+        payload = json.loads(unquote(deep_link_match.group(1).removeprefix("obtainium://app/")))  # type: ignore[union-attr]
 
         self.assertEqual(payload["id"], "app.revanced.android.youtube")
         self.assertEqual(payload["overrideSource"], "HTML")

--- a/tests/test_obtainium_export.py
+++ b/tests/test_obtainium_export.py
@@ -122,7 +122,7 @@ class ObtainiumExportTests(TestCase):
             }
 
             generate_obtainium_export(updates_info, config)
-            index_content = Path(temp_dir, "obtainium_sources", "index.html").read_text(encoding="utf_8")
+            index_content = Path(temp_dir, "index.html").read_text(encoding="utf_8")
 
         self.assertIn('<span class="app-name">YouTube</span>', index_content)
         self.assertIn("https://github.com/ImranR98/Obtainium", index_content)
@@ -164,7 +164,7 @@ class ObtainiumExportTests(TestCase):
             }
 
             generate_obtainium_export(updates_info, config)
-            index_path = Path(temp_dir, "obtainium_sources", "index.html")
+            index_path = Path(temp_dir, "index.html")
 
         self.assertFalse(index_path.exists())
 

--- a/tests/test_obtainium_export.py
+++ b/tests/test_obtainium_export.py
@@ -4,18 +4,21 @@
 # unittest keeps this file aligned with the rest of the repository test suite.
 # ruff: noqa: PT009
 
+import json
+import re
 from contextlib import chdir
 from pathlib import Path
 from tempfile import TemporaryDirectory
 from types import SimpleNamespace
-from typing import TYPE_CHECKING, Self, cast
+from typing import Self, cast
 from unittest import TestCase
+from urllib.parse import unquote
+
+from environs import Env
 
 from src.app import APP
+from src.config import RevancedConfig
 from src.utils import generate_obtainium_export
-
-if TYPE_CHECKING:
-    from src.config import RevancedConfig
 
 
 class _Env:
@@ -75,6 +78,7 @@ class ObtainiumExportTests(TestCase):
                 SimpleNamespace(
                     obtainium_export=True,
                     obtainium_github_tag="release tag",
+                    obtainium_site_export=False,
                     env=_Env("owner/repo"),
                 ),
             )
@@ -94,3 +98,83 @@ class ObtainiumExportTests(TestCase):
             html_content,
         )
         self.assertIn("1&lt;2", html_content)
+
+    def test_generate_obtainium_export_site_export_builds_deep_link(self: Self) -> None:
+        """Site export should add a package-scoped obtainium://app/ deep link and an index page."""
+        with TemporaryDirectory() as temp_dir, chdir(temp_dir):
+            config = cast(
+                "RevancedConfig",
+                SimpleNamespace(
+                    obtainium_export=True,
+                    obtainium_github_tag="latest",
+                    obtainium_site_export=True,
+                    obtainium_version_extraction_regex=r"Version([\w.]+)-PatchVersion[v]?([\w.]+)-PatchSet",
+                    obtainium_version_match_group="$1+$2",
+                    env=_Env("owner/repo"),
+                ),
+            )
+            updates_info = {
+                "YouTube": {
+                    "app_version": "20.47.62",
+                    "output_file_name": "ReYouTube-Version20.47.62-PatchVersionv1.0.0-PatchSetabc123-output.apk",
+                    "app_dump": {"package_name": "app.revanced.android.youtube"},
+                },
+            }
+
+            generate_obtainium_export(updates_info, config)
+            index_content = Path(temp_dir, "obtainium_sources", "index.html").read_text(encoding="utf_8")
+
+        self.assertIn("Add YouTube to Obtainium", index_content)
+        deep_link = index_content.split('href="')[1].split('"')[0]
+        payload = json.loads(unquote(deep_link.removeprefix("obtainium://app/")))
+
+        self.assertEqual(payload["id"], "app.revanced.android.youtube")
+        self.assertEqual(payload["overrideSource"], "HTML")
+        self.assertEqual(
+            payload["url"],
+            "https://raw.githubusercontent.com/owner/repo/changelogs/obtainium_sources/youtube.html",
+        )
+
+        additional_settings = json.loads(payload["additionalSettings"])
+        self.assertEqual(additional_settings["matchGroupToUse"], "$1+$2")
+        self.assertTrue(additional_settings["versionDetection"])
+
+    def test_generate_obtainium_export_site_export_skips_app_without_package_name(self: Self) -> None:
+        """An app_dump missing package_name should skip its deep link but not crash the export."""
+        with TemporaryDirectory() as temp_dir, chdir(temp_dir):
+            config = cast(
+                "RevancedConfig",
+                SimpleNamespace(
+                    obtainium_export=True,
+                    obtainium_github_tag="latest",
+                    obtainium_site_export=True,
+                    obtainium_version_extraction_regex="",
+                    obtainium_version_match_group="",
+                    env=_Env("owner/repo"),
+                ),
+            )
+            updates_info = {
+                "YouTube": {
+                    "app_version": "20.47.62",
+                    "output_file_name": "youtube-output.apk",
+                    "app_dump": {},
+                },
+            }
+
+            generate_obtainium_export(updates_info, config)
+            index_path = Path(temp_dir, "obtainium_sources", "index.html")
+
+        self.assertFalse(index_path.exists())
+
+    def test_default_version_extraction_regex_handles_optional_patch_prefix(self: Self) -> None:
+        """The shipped default regex must match patch bundle versions with or without a leading 'v'."""
+        config = RevancedConfig(Env())
+        regex = config.obtainium_version_extraction_regex
+
+        with_v = re.search(regex, "ReYouTube-Version20.47.62-PatchVersionv1.0.0-PatchSetabc123-output.apk")
+        without_v = re.search(regex, "ReYouTube-Version20.47.62-PatchVersion1.0.0-PatchSetabc123-output.apk")
+
+        self.assertIsNotNone(with_v)
+        self.assertIsNotNone(without_v)
+        self.assertEqual(with_v.groups(), ("20.47.62", "1.0.0"))  # type: ignore[union-attr]
+        self.assertEqual(without_v.groups(), ("20.47.62", "1.0.0"))  # type: ignore[union-attr]


### PR DESCRIPTION
## Summary

`OBTAINIUM_EXPORT` already generates a per-app HTML source page for Obtainium, but adding it still meant manually pasting the raw URL into Obtainium and configuring an "HTML" override source and version regex by hand. There was also no `index.html`, so pointing GitHub Pages at the `obtainium_sources` folder didn't actually serve anything.

This adds `OBTAINIUM_SITE_EXPORT`, which generates `obtainium_sources/index.html` - a page listing every patched app as a one-click `obtainium://app/...` deep link. Point GitHub Pages at the `changelogs` branch, `/obtainium_sources` folder, and tapping a link on an Android device with Obtainium installed adds that app's source with no manual configuration.

- `src/utils.py`: builds each deep link's `additionalSettings` (source URL, author, name, version-extraction regex) and writes the index page. Verified the payload against Obtainium's actual parsing source (`App.fromJson`/`appJSONCompatibilityModifiers`) - required fields, `overrideSource` handling, and default-merging for omitted `additionalSettings` keys all confirmed to match.
- `src/config.py`: three new optional vars - `OBTAINIUM_SITE_EXPORT`, `OBTAINIUM_VERSION_EXTRACTION_REGEX` (defaults to a pattern matching this project's own output filename convention, handling patch versions with or without a leading `v`), and `OBTAINIUM_VERSION_MATCH_GROUP`.
- The index page is styled (card rows, light/dark theming, mobile-friendly) and links to Obtainium's GitHub for anyone who lands on it without the app installed.
- `README.md` / `obtainium.md`: the Obtainium docs had grown to five variables plus setup/mechanism explanation, so this pulls the detail into a new `obtainium.md` and leaves a summary table in the README, matching the existing Global/App Level Config table style.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added optional Obtainium site export with one-tap installation links.
  * Added configurable version extraction from release filenames.
  * Generated per-app Obtainium source pages and a central app index.

* **Documentation**
  * Added setup and configuration guidance for Obtainium integration, including publishing through GitHub Pages.

* **Bug Fixes**
  * Apps without package metadata are now skipped during site generation.
  * Improved version detection for releases with or without patch versions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->